### PR TITLE
Fixed regex matching issue.

### DIFF
--- a/src/main/java/us/springett/cvss/Cvss.java
+++ b/src/main/java/us/springett/cvss/Cvss.java
@@ -27,8 +27,16 @@ import java.util.regex.Pattern;
  */
 public interface Cvss {
 
-    Pattern CVSSv2_PATTERN = Pattern.compile("AV:[NAL]\\/AC:[LMH]\\/A[Uu]:[NSM]\\/C:[NPC]\\/I:[NPC]\\/A:[NPC]\\/E:\b(F|H|U|POC|ND)\b\\/RL:\b(W|U|TF|OF|ND)\b\\/RC:\b(C|UR|UC|ND)\b");
-    Pattern CVSSv3_PATTERN = Pattern.compile("AV:[NALP]\\/AC:[LH]\\/PR:[NLH]\\/UI:[NR]\\/S:[UC]\\/C:[NLH]\\/I:[NLH]\\/A:[NLH]\\/E:[F|H|U|P|X]\\/RL:[W|U|T|O|X]\\/RC:[C|R|U|X]");
+    String V2_PATTERN = "AV:[NAL]\\/AC:[LMH]\\/A[Uu]:[NSM]\\/C:[NPC]\\/I:[NPC]\\/A:[NPC]";
+    String V2_TEMPORAL = "\\/E:\\b(F|H|U|POC|ND)\\b\\/RL:\\b(W|U|TF|OF|ND)\\b\\/RC:\\b(C|UR|UC|ND)\\b";
+
+    String V3_PATTERN = "AV:[NALP]\\/AC:[LH]\\/PR:[NLH]\\/UI:[NR]\\/S:[UC]\\/C:[NLH]\\/I:[NLH]\\/A:[NLH]";
+    String V3_TEMPORAL = "\\/E:[F|H|U|P|X]\\/RL:[W|U|T|O|X]\\/RC:[C|R|U|X]";
+
+    Pattern CVSSv2_PATTERN = Pattern.compile(V2_PATTERN);
+    Pattern CVSSv2_PATTERN_TEMPORAL = Pattern.compile(V2_PATTERN + V2_TEMPORAL);
+    Pattern CVSSv3_PATTERN = Pattern.compile(V3_PATTERN);
+    Pattern CVSSv3_PATTERN_TEMPORAL = Pattern.compile(V3_PATTERN + V3_TEMPORAL);
 
     /**
      * Calculates a CVSS score.
@@ -58,42 +66,62 @@ public interface Cvss {
             return null;
         }
         Matcher v2Matcher = CVSSv2_PATTERN.matcher(vector);
+        Matcher v2TemporalMatcher = CVSSv2_PATTERN_TEMPORAL.matcher(vector);
         Matcher v3Matcher = CVSSv3_PATTERN.matcher(vector);
+        Matcher v3TemporalMatcher = CVSSv3_PATTERN_TEMPORAL.matcher(vector);
 
-        if (v2Matcher.find()) {
-            // Found a valid CVSSv2 vector
-            String matchedVector = v2Matcher.group(0);
+        if (v2TemporalMatcher.find()) {
+            String matchedVector = v2TemporalMatcher.group(0);
             StringTokenizer st = new StringTokenizer(matchedVector, "/");
-            CvssV2 cvssV2 = new CvssV2();
-            cvssV2.attackVector(CvssV2.AttackVector.fromString(st.nextElement().toString().split(":")[1]));
-            cvssV2.attackComplexity(CvssV2.AttackComplexity.fromString(st.nextElement().toString().split(":")[1]));
-            cvssV2.authentication(CvssV2.Authentication.fromString(st.nextElement().toString().split(":")[1]));
-            cvssV2.confidentiality(CvssV2.CIA.fromString(st.nextElement().toString().split(":")[1]));
-            cvssV2.integrity(CvssV2.CIA.fromString(st.nextElement().toString().split(":")[1]));
-            cvssV2.availability(CvssV2.CIA.fromString(st.nextElement().toString().split(":")[1]));
+            CvssV2 cvssV2 = getCvssV2BaseVector(st);
             cvssV2.exploitability(CvssV2.Exploitability.fromString(st.nextElement().toString().split(":")[1]));
             cvssV2.remediationLevel(CvssV2.RemediationLevel.fromString(st.nextElement().toString().split(":")[1]));
             cvssV2.reportConfidence(CvssV2.ReportConfidence.fromString(st.nextElement().toString().split(":")[1]));
             return cvssV2;
-        } else if (v3Matcher.find()) {
-            // Found a valid CVSSv3 vector
-            String matchedVector = v3Matcher.group(0);
+        } else if (v2Matcher.find()) {
+            // Found a valid CVSSv2 vector with temporal values
+            String matchedVector = v2Matcher.group(0);
             StringTokenizer st = new StringTokenizer(matchedVector, "/");
-            CvssV3 cvssV3 = new CvssV3();
-            cvssV3.attackVector(CvssV3.AttackVector.fromString(st.nextElement().toString().split(":")[1]));
-            cvssV3.attackComplexity(CvssV3.AttackComplexity.fromString(st.nextElement().toString().split(":")[1]));
-            cvssV3.privilegesRequired(CvssV3.PrivilegesRequired.fromString(st.nextElement().toString().split(":")[1]));
-            cvssV3.userInteraction(CvssV3.UserInteraction.fromString(st.nextElement().toString().split(":")[1]));
-            cvssV3.scope(CvssV3.Scope.fromString(st.nextElement().toString().split(":")[1]));
-            cvssV3.confidentiality(CvssV3.CIA.fromString(st.nextElement().toString().split(":")[1]));
-            cvssV3.integrity(CvssV3.CIA.fromString(st.nextElement().toString().split(":")[1]));
-            cvssV3.availability(CvssV3.CIA.fromString(st.nextElement().toString().split(":")[1]));
+            return getCvssV2BaseVector(st);
+        } else if (v3TemporalMatcher.find()) {
+            // Found a valid CVSSv3 vector with temporal values
+            String matchedVector = v3TemporalMatcher.group(0);
+            StringTokenizer st = new StringTokenizer(matchedVector, "/");
+            CvssV3 cvssV3 = getCvssV3BaseVector(st);
             cvssV3.exploitability(CvssV3.Exploitability.fromString(st.nextElement().toString().split(":")[1]));
             cvssV3.remediationLevel(CvssV3.RemediationLevel.fromString(st.nextElement().toString().split(":")[1]));
             cvssV3.reportConfidence(CvssV3.ReportConfidence.fromString(st.nextElement().toString().split(":")[1]));
             return cvssV3;
+        } else if (v3Matcher.find()) {
+            // Found a valid CVSSv3 vector
+            String matchedVector = v3Matcher.group(0);
+            StringTokenizer st = new StringTokenizer(matchedVector, "/");
+            return getCvssV3BaseVector(st);
         }
         return null;
     }
 
+    static CvssV2 getCvssV2BaseVector(StringTokenizer st) {
+        CvssV2 cvssV2 = new CvssV2();
+        cvssV2.attackVector(CvssV2.AttackVector.fromString(st.nextElement().toString().split(":")[1]));
+        cvssV2.attackComplexity(CvssV2.AttackComplexity.fromString(st.nextElement().toString().split(":")[1]));
+        cvssV2.authentication(CvssV2.Authentication.fromString(st.nextElement().toString().split(":")[1]));
+        cvssV2.confidentiality(CvssV2.CIA.fromString(st.nextElement().toString().split(":")[1]));
+        cvssV2.integrity(CvssV2.CIA.fromString(st.nextElement().toString().split(":")[1]));
+        cvssV2.availability(CvssV2.CIA.fromString(st.nextElement().toString().split(":")[1]));
+        return cvssV2;
+    }
+
+    static CvssV3 getCvssV3BaseVector(StringTokenizer st) {
+        CvssV3 cvssV3 = new CvssV3();
+        cvssV3.attackVector(CvssV3.AttackVector.fromString(st.nextElement().toString().split(":")[1]));
+        cvssV3.attackComplexity(CvssV3.AttackComplexity.fromString(st.nextElement().toString().split(":")[1]));
+        cvssV3.privilegesRequired(CvssV3.PrivilegesRequired.fromString(st.nextElement().toString().split(":")[1]));
+        cvssV3.userInteraction(CvssV3.UserInteraction.fromString(st.nextElement().toString().split(":")[1]));
+        cvssV3.scope(CvssV3.Scope.fromString(st.nextElement().toString().split(":")[1]));
+        cvssV3.confidentiality(CvssV3.CIA.fromString(st.nextElement().toString().split(":")[1]));
+        cvssV3.integrity(CvssV3.CIA.fromString(st.nextElement().toString().split(":")[1]));
+        cvssV3.availability(CvssV3.CIA.fromString(st.nextElement().toString().split(":")[1]));
+        return cvssV3;
+    }
 }

--- a/src/main/java/us/springett/cvss/Cvss.java
+++ b/src/main/java/us/springett/cvss/Cvss.java
@@ -71,6 +71,7 @@ public interface Cvss {
         Matcher v3TemporalMatcher = CVSSv3_PATTERN_TEMPORAL.matcher(vector);
 
         if (v2TemporalMatcher.find()) {
+            // Found a valid CVSSv2 vector with temporal values
             String matchedVector = v2TemporalMatcher.group(0);
             StringTokenizer st = new StringTokenizer(matchedVector, "/");
             CvssV2 cvssV2 = getCvssV2BaseVector(st);
@@ -79,7 +80,7 @@ public interface Cvss {
             cvssV2.reportConfidence(CvssV2.ReportConfidence.fromString(st.nextElement().toString().split(":")[1]));
             return cvssV2;
         } else if (v2Matcher.find()) {
-            // Found a valid CVSSv2 vector with temporal values
+            // Found a valid CVSSv2 vector
             String matchedVector = v2Matcher.group(0);
             StringTokenizer st = new StringTokenizer(matchedVector, "/");
             return getCvssV2BaseVector(st);

--- a/src/test/java/us/springett/cvss/CvssV2Test.java
+++ b/src/test/java/us/springett/cvss/CvssV2Test.java
@@ -307,4 +307,19 @@ public class CvssV2Test {
         Assert.assertEquals(2.3, score.getTemporalScore(), 0);
         Assert.assertEquals(null, "(AV:N/AC:H/Au:N/C:P/I:N/A:N/E:F/RL:W/RC:ND)", cvssV2Temporal.getVector());
     }
+
+    @Test
+    public void testRegexPattern() {
+        // Without temporal vector elements
+        String cvss2Vector = "(AV:N/AC:H/Au:N/C:P/I:N/A:N)";
+        Cvss cvssV2 = Cvss.fromVector(cvss2Vector);
+        Assert.assertNotNull(cvssV2);
+        Assert.assertEquals(cvss2Vector, cvssV2.getVector());
+
+        // With temporal vector elements
+        cvss2Vector = "(AV:N/AC:H/Au:N/C:P/I:N/A:N/E:F/RL:W/RC:ND)";
+        cvssV2 = Cvss.fromVector(cvss2Vector);
+        Assert.assertNotNull(cvssV2);
+        Assert.assertEquals(cvss2Vector, cvssV2.getVector());
+    }
 }

--- a/src/test/java/us/springett/cvss/CvssV3Test.java
+++ b/src/test/java/us/springett/cvss/CvssV3Test.java
@@ -327,4 +327,19 @@ public class CvssV3Test {
         Assert.assertEquals(7.2, score.getTemporalScore(), 0);
         Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:X/RL:X/RC:C", cvssV3.getVector());
     }
+
+    @Test
+    public void testRegexPattern() {
+        // Without temporal vector elements
+        String cvss3Vector = "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H";
+        Cvss cvssV3 = Cvss.fromVector(cvss3Vector);
+        Assert.assertNotNull(cvssV3);
+        Assert.assertEquals(cvss3Vector, cvssV3.getVector());
+
+        // With temporal vector elements
+        cvss3Vector = "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:X/RL:X/RC:C";
+        cvssV3 = Cvss.fromVector(cvss3Vector);
+        Assert.assertNotNull(cvssV3);
+        Assert.assertEquals(cvss3Vector, cvssV3.getVector());
+    }
 }


### PR DESCRIPTION
The tests I added for the temporal scoring were not rigorous enough to catch a bug I introduced when using the "fromVector(String vector)" method on the Cvss class.

I had failed to properly escape a character in the regex. Once I found the issue and corrected it I discovered more work needed to be done to make sure all of the existing code remained backward compatible.

I apologize for the (rather embarrasing) oversight and the inconvenience.