### PR TITLE
Fixed Environmental Score calculation in CvssV3_1

### DIFF
--- a/src/main/java/us/springett/cvss/CvssV3.java
+++ b/src/main/java/us/springett/cvss/CvssV3.java
@@ -333,6 +333,7 @@ public class CvssV3 implements Cvss {
     }
 
     protected double roundNearestTenth(double d) {
+        if(d < 0) return 0; // negative values are not valid, using zero instead
         return Math.round(d * 10.0) / 10.0;
     }
 

--- a/src/main/java/us/springett/cvss/CvssV3_1.java
+++ b/src/main/java/us/springett/cvss/CvssV3_1.java
@@ -1,5 +1,8 @@
 package us.springett.cvss;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class CvssV3_1 extends CvssV3 {
 
     /**** Environmental Score Metric Group ****/
@@ -130,64 +133,81 @@ public class CvssV3_1 extends CvssV3 {
      * {@inheritDoc}
      */
     public Score calculateScore() {
+        /* GATHER WEIGHTS FOR ALL CONDITIONAL METRICS */
+
+        // PrivilegesRequired (PR) depends on the value of Scope (S)
         final double prWeight = (Scope.UNCHANGED == s) ? pr.weight : pr.scopeChangedWeight;
+
+        // for metrics that are modified versions of Base Score metrics use the value of the Base Score metric if the
+        // modified version value is "X" ("not defined")
+        final double mavWeight = (mav.shorthand.equalsIgnoreCase("X")) ? av.weight : mav.weight;
+        final double macWeight = (mac.shorthand.equalsIgnoreCase("X")) ? ac.weight : mac.weight;
+        final double muiWeight = (mui.shorthand.equalsIgnoreCase("X")) ? ui.weight : mui.weight;
+        final double mcWeight = (mc.shorthand.equalsIgnoreCase("X")) ? c.weight : mc.weight;
+        final double miWeight = (mi.shorthand.equalsIgnoreCase("X")) ? i.weight : mi.weight;
+        final double maWeight = (ma.shorthand.equalsIgnoreCase("X")) ? a.weight : ma.weight;
+        final double msWeight = (ms.shorthand.equalsIgnoreCase("X")) ? s.weight : ms.weight;
+
+        // ModifiedPrivilegesRequired (MPR) depends on the value of Modified Scope (MS) or Scope (S) if MS is "X" (not defined)
         final double mprWeight;
+        if(ms == ModifiedScope.UNCHANGED || (ms == ModifiedScope.NOT_DEFINED && s == Scope.UNCHANGED)){
+            mprWeight = (mpr.shorthand.equalsIgnoreCase("X")) ? pr.weight : mpr.weight;
+        } else {
+            mprWeight = (mpr.shorthand.equalsIgnoreCase("X")) ? pr.scopeChangedWeight : mpr.scopeChangedWeight;
+        }
 
-        final double exploitabilitySubScore = exploitabilityCoefficient * av.weight * ac.weight * prWeight * ui.weight;
-        final double modifiedExploitabilitySubScore;
-        final double impactSubScoreMultiplier = 1 - ((1 - c.weight) * (1 - i.weight) * (1 - a.weight));
-        final double modifiedImpactSubScoreMultiplier = Math.min(1 - ((1 - cr.weight * mc.weight) * (1 - ir.weight * mi.weight) * (1 - ar.weight * ma.weight)), 0.915);
+        /* CALCULATE THE CVSS SCORE */
 
+        // Base Score
+        final double impactSubScore = (1 - ((1 - c.weight) * (1 - i.weight) * (1 - a.weight)));
+        final double exploitability = exploitabilityCoefficient * av.weight * ac.weight * prWeight * ui.weight;
+        final double impact;
         final double baseScore;
-        double impactSubScore;
-        final double temporalScore;
-        final double environmentalScore;
-        double modifiedImpactSubScore;
 
-        if (Scope.UNCHANGED == s) {
-            impactSubScore = s.weight * impactSubScoreMultiplier;
+        if (s == Scope.UNCHANGED) {
+            impact = s.weight * impactSubScore;
         } else {
-            impactSubScore = s.weight * (impactSubScoreMultiplier - 0.029) - 3.25 * Math.pow(impactSubScoreMultiplier - 0.02, 15);
+            impact = s.weight * (impactSubScore - 0.029) - 3.25 * Math.pow((impactSubScore - 0.02), 15);
         }
 
-        if (impactSubScore <= 0) {
+        if (impact <= 0) {
             baseScore = 0;
-            impactSubScore = 0;
         } else {
-            if (Scope.UNCHANGED == s) {
-                baseScore = roundUp1(Math.min((impactSubScore + exploitabilitySubScore), 10));
+            if (s == Scope.UNCHANGED) {
+                baseScore = roundUp1(Math.min((exploitability + impact), 10));
             } else {
-                baseScore = roundUp1(Math.min((impactSubScore + exploitabilitySubScore) * scopeCoefficient, 10));
+                baseScore = roundUp1(Math.min((scopeCoefficient * (exploitability + impact)), 10));
             }
         }
 
-        temporalScore = roundUp1(baseScore * e.weight * rl.weight * rc.weight);
+        // Temporal Score
+        final double temporalScore = roundUp1(baseScore * e.weight * rl.weight * rc.weight);
 
-        if (ModifiedScope.UNCHANGED == ms) {
-            mprWeight = mpr.weight;
-            modifiedImpactSubScore = ms.weight * modifiedImpactSubScoreMultiplier;
-        } else if (ModifiedScope.CHANGED == ms) {
-            mprWeight = mpr.scopeChangedWeight;
-            modifiedImpactSubScore = ms.weight * (modifiedImpactSubScoreMultiplier - 0.029) - 3.25 * Math.pow((modifiedImpactSubScoreMultiplier * 0.9731 - 0.02), 13);
+        // Environmental Score
+        // - *modifiedExploitability* and *modifiedImpact* recalculate the Base Score exploitability/impact using any
+        //   modified values from the Environmental metrics in place of the values specified in the Base Score (if any
+        //   have been defined - otherwise the Base Score values are used)
+        //   have been defined - otherwise the Base Score values are used)
+        final double modifiedImpactSubScore = Math.min(1 - ((1 - mcWeight * cr.weight) * (1 - miWeight * ir.weight) * (1 - maWeight * ar.weight)), 0.915);
+        final double modifiedExploitability = exploitabilityCoefficient * mavWeight * macWeight * mprWeight * muiWeight;
+        final double modifiedImpact;
+        final double envScore;
+
+        if (ms == ModifiedScope.UNCHANGED || (ms == ModifiedScope.NOT_DEFINED && s == Scope.UNCHANGED)) {
+            modifiedImpact = msWeight * modifiedImpactSubScore;
         } else {
-            mprWeight = 0;
-            modifiedImpactSubScore = 0;
+            modifiedImpact = msWeight * (modifiedImpactSubScore - 0.029) - 3.25 * Math.pow((modifiedImpactSubScore * 0.9731 - 0.02), 13);
         }
 
-        modifiedExploitabilitySubScore = exploitabilityCoefficient * mav.weight * mac.weight * mprWeight * mui.weight;
-
-        if (modifiedImpactSubScore <= 0) {
-            environmentalScore = 0;
-            modifiedImpactSubScore = 0;
+        if (modifiedImpact <= 0) {
+            envScore = 0;
+        } else if (ms == ModifiedScope.UNCHANGED || (ms == ModifiedScope.NOT_DEFINED && s == Scope.UNCHANGED)) {
+            envScore = roundUp1(roundUp1(Math.min((modifiedImpact + modifiedExploitability), 10)) * e.weight * rl.weight * rc.weight);
         } else {
-            if (ModifiedScope.UNCHANGED == ms) {
-                environmentalScore = roundUp1(roundUp1(Math.min((modifiedImpactSubScore + modifiedExploitabilitySubScore), 10)) * e.weight * rl.weight * rc.weight);
-            } else {
-                environmentalScore = roundUp1(roundUp1(Math.min(1.08 * (modifiedImpactSubScore + modifiedExploitabilitySubScore), 10)) * e.weight * rl.weight * rc.weight);
-            }
+            envScore = roundUp1(roundUp1(Math.min(scopeCoefficient * (modifiedImpact + modifiedExploitability), 10)) * e.weight * rl.weight * rc.weight);
         }
 
-        return new Score(baseScore, roundNearestTenth(impactSubScore), roundNearestTenth(exploitabilitySubScore), temporalScore, environmentalScore, roundNearestTenth(modifiedImpactSubScore));
+        return new Score(roundNearestTenth(baseScore), roundNearestTenth(impact), roundNearestTenth(exploitability), roundNearestTenth(temporalScore), roundNearestTenth(envScore), roundNearestTenth(modifiedImpact));
     }
 
     private double roundUp1(double d) {
@@ -203,30 +223,35 @@ public class CvssV3_1 extends CvssV3 {
      * {@inheritDoc}
      */
     public String getVector() {
-        return "CVSS:3.1/" +
-                "AV:" + av.shorthand + "/" +
-                "AC:" + ac.shorthand + "/" +
-                "PR:" + pr.shorthand + "/" +
-                "UI:" + ui.shorthand + "/" +
-                "S:" + s.shorthand + "/" +
-                "C:" + c.shorthand + "/" +
-                "I:" + i.shorthand + "/" +
-                "A:" + a.shorthand +
-                ((e != null && rl != null && rc != null) ? (
-                        "/E:" + e.shorthand + "/" +
-                                "RL:" + rl.shorthand + "/" +
-                                "RC:" + rc.shorthand) : "") +
-                "/CR:" + cr.shorthand + "/" +
-                "IR:" + ir.shorthand + "/" +
-                "AR:" + ar.shorthand + "/" +
-                "MAV:" + mav.shorthand + "/" +
-                "MAC:" + mac.shorthand + "/" +
-                "MPR:" + mpr.shorthand + "/" +
-                "MUI:" + mui.shorthand + "/" +
-                "MS:" + ms.shorthand + "/" +
-                "MC:" + mc.shorthand + "/" +
-                "MI:" + mi.shorthand + "/" +
-                "MA:" + ma.shorthand;
+        List<String> vector = new ArrayList<>();
+        vector.add("CVSS:3.1");
+
+        if (av != null) vector.add("AV:" + av.shorthand);
+        if (ac != null) vector.add("AC:" + ac.shorthand);
+        if (pr != null) vector.add("PR:" + pr.shorthand);
+        if (ui != null) vector.add("UI:" + ui.shorthand);
+        if (s != null) vector.add("S:" + s.shorthand);
+        if (c != null) vector.add("C:" + c.shorthand);
+        if (i != null) vector.add("I:" + i.shorthand);
+        if (a != null) vector.add("A:" + a.shorthand);
+
+        if (e != null && (!e.shorthand.equalsIgnoreCase("X"))) vector.add("E:" + e.shorthand);
+        if (rl != null && (!rl.shorthand.equalsIgnoreCase("X"))) vector.add("RL:" + rl.shorthand);
+        if (rc != null && (!rc.shorthand.equalsIgnoreCase("X"))) vector.add("RC:" + rc.shorthand);
+
+        if (cr != null && (!cr.shorthand.equalsIgnoreCase("X"))) vector.add("CR:" + cr.shorthand);
+        if (ir != null && (!ir.shorthand.equalsIgnoreCase("X"))) vector.add("IR:" + ir.shorthand);
+        if (ar != null && (!ar.shorthand.equalsIgnoreCase("X"))) vector.add("AR:" + ar.shorthand);
+        if (mav != null && (!mav.shorthand.equalsIgnoreCase("X"))) vector.add("MAV:" + mav.shorthand);
+        if (mac != null && (!mac.shorthand.equalsIgnoreCase("X"))) vector.add("MAC:" + mac.shorthand);
+        if (mpr != null && (!mpr.shorthand.equalsIgnoreCase("X"))) vector.add("MPR:" + mpr.shorthand);
+        if (mui != null && (!mui.shorthand.equalsIgnoreCase("X"))) vector.add("MUI:" + mui.shorthand);
+        if (ms != null && (!ms.shorthand.equalsIgnoreCase("X"))) vector.add("MS:" + ms.shorthand);
+        if (mc != null && (!mc.shorthand.equalsIgnoreCase("X"))) vector.add("MC:" + mc.shorthand);
+        if (mi != null && (!mi.shorthand.equalsIgnoreCase("X"))) vector.add("MI:" + mi.shorthand);
+        if (ma != null && (!ma.shorthand.equalsIgnoreCase("X"))) vector.add("MA:" + ma.shorthand);
+
+        return String.join("/", vector);
     }
 
     public ModifiedAttackVector getModifiedAttackVector() {

--- a/src/main/java/us/springett/cvss/CvssV3_1.java
+++ b/src/main/java/us/springett/cvss/CvssV3_1.java
@@ -150,7 +150,7 @@ public class CvssV3_1 extends CvssV3 {
 
         // ModifiedPrivilegesRequired (MPR) depends on the value of Modified Scope (MS) or Scope (S) if MS is "X" (not defined)
         final double mprWeight;
-        if(ms == ModifiedScope.UNCHANGED || (ms == ModifiedScope.NOT_DEFINED && s == Scope.UNCHANGED)){
+        if (ms == ModifiedScope.UNCHANGED || (ms == ModifiedScope.NOT_DEFINED && s == Scope.UNCHANGED)) {
             mprWeight = (mpr.shorthand.equalsIgnoreCase("X")) ? pr.weight : mpr.weight;
         } else {
             mprWeight = (mpr.shorthand.equalsIgnoreCase("X")) ? pr.scopeChangedWeight : mpr.scopeChangedWeight;
@@ -252,6 +252,45 @@ public class CvssV3_1 extends CvssV3 {
         if (ma != null && (!ma.shorthand.equalsIgnoreCase("X"))) vector.add("MA:" + ma.shorthand);
 
         return String.join("/", vector);
+    }
+
+    /**
+     * Return the vector string of the {@link CvssV3_1}.
+     *
+     * @param includeAll includes all NOT_DEFINED fields in the vector string if true, removes them if false
+     * @return the vector string of the {@link CvssV3_1}
+     */
+    public String getVector(final boolean includeAll) {
+        if (includeAll) {
+            List<String> vector = new ArrayList<>();
+            vector.add("CVSS:3.1");
+            if (av != null) vector.add("AV:" + av.shorthand);
+            if (ac != null) vector.add("AC:" + ac.shorthand);
+            if (pr != null) vector.add("PR:" + pr.shorthand);
+            if (ui != null) vector.add("UI:" + ui.shorthand);
+            if (s != null) vector.add("S:" + s.shorthand);
+            if (c != null) vector.add("C:" + c.shorthand);
+            if (i != null) vector.add("I:" + i.shorthand);
+            if (a != null) vector.add("A:" + a.shorthand);
+
+            if (e != null) vector.add("E:" + e.shorthand);
+            if (rl != null) vector.add("RL:" + rl.shorthand);
+            if (rc != null) vector.add("RC:" + rc.shorthand);
+
+            if (cr != null) vector.add("CR:" + cr.shorthand);
+            if (ir != null) vector.add("IR:" + ir.shorthand);
+            if (ar != null) vector.add("AR:" + ar.shorthand);
+            if (mav != null) vector.add("MAV:" + mav.shorthand);
+            if (mac != null) vector.add("MAC:" + mac.shorthand);
+            if (mpr != null) vector.add("MPR:" + mpr.shorthand);
+            if (mui != null) vector.add("MUI:" + mui.shorthand);
+            if (ms != null) vector.add("MS:" + ms.shorthand);
+            if (mc != null) vector.add("MC:" + mc.shorthand);
+            if (mi != null) vector.add("MI:" + mi.shorthand);
+            if (ma != null) vector.add("MA:" + ma.shorthand);
+            return String.join("/", vector);
+        }
+        return getVector();
     }
 
     public ModifiedAttackVector getModifiedAttackVector() {

--- a/src/test/java/us/springett/cvss/CvssV3_1Test.java
+++ b/src/test/java/us/springett/cvss/CvssV3_1Test.java
@@ -365,7 +365,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:X/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.Exploitability.NOT_DEFINED, cvssV3_1.getExploitability());
 
         cvssV3_1.exploitability(CvssV3_1.Exploitability.UNPROVEN);
@@ -423,7 +423,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:X/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.RemediationLevel.NOT_DEFINED, cvssV3_1.getRemediationLevel());
 
         cvssV3_1.remediationLevel(CvssV3_1.RemediationLevel.OFFICIAL);
@@ -481,7 +481,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:X/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ReportConfidence.NOT_DEFINED, cvssV3_1.getReportConfidence());
 
         cvssV3_1.reportConfidence(CvssV3_1.ReportConfidence.UNKNOWN);
@@ -529,7 +529,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:X/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ConfidentialityRequirement.NOT_DEFINED, cvssV3_1.getConfidentialityRequirement());
 
         cvssV3_1.confidentialityRequirement(CvssV3_1.ConfidentialityRequirement.LOW);
@@ -576,7 +576,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:X/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.IntegrityRequirement.NOT_DEFINED, cvssV3_1.getIntegrityRequirement());
 
         cvssV3_1.integrityRequirement(CvssV3_1.IntegrityRequirement.LOW);
@@ -623,7 +623,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:X/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.AvailabilityRequirement.NOT_DEFINED, cvssV3_1.getAvailabilityRequirement());
 
         cvssV3_1.availabilityRequirement(CvssV3_1.AvailabilityRequirement.LOW);
@@ -670,7 +670,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:X/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ModifiedAttackVector.NOT_DEFINED, cvssV3_1.getModifiedAttackVector());
 
         cvssV3_1.modifiedAttackVector(CvssV3_1.ModifiedAttackVector.NETWORK);
@@ -728,7 +728,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:X/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ModifiedAttackComplexity.NOT_DEFINED, cvssV3_1.getModifiedAttackComplexity());
 
         cvssV3_1.modifiedAttackComplexity(CvssV3_1.ModifiedAttackComplexity.LOW);
@@ -764,7 +764,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:X/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ModifiedPrivilegesRequired.NOT_DEFINED, cvssV3_1.getModifiedPrivilegesRequired());
 
         cvssV3_1.modifiedPrivilegesRequired(CvssV3_1.ModifiedPrivilegesRequired.NONE);
@@ -811,7 +811,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:X/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ModifiedUserInteraction.NOT_DEFINED, cvssV3_1.getModifiedUserInteraction());
 
         cvssV3_1.modifiedUserInteraction(CvssV3_1.ModifiedUserInteraction.NONE);
@@ -847,7 +847,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:X/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ModifiedScope.NOT_DEFINED, cvssV3_1.getModifiedScope());
 
         cvssV3_1.modifiedScope(CvssV3_1.ModifiedScope.UNCHANGED);
@@ -883,7 +883,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:X/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ModifiedCIA.NOT_DEFINED, cvssV3_1.getModifiedConfidentialityImpact());
 
         cvssV3_1.modifiedConfidentialityImpact(CvssV3_1.ModifiedCIA.NONE);
@@ -930,7 +930,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:X/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ModifiedCIA.NOT_DEFINED, cvssV3_1.getModifiedIntegrityImpact());
 
         cvssV3_1.modifiedIntegrityImpact(CvssV3_1.ModifiedCIA.NONE);
@@ -977,7 +977,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:X", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ModifiedCIA.NOT_DEFINED, cvssV3_1.getModifiedAvailabilityImpact());
 
         cvssV3_1.modifiedAvailabilityImpact(CvssV3_1.ModifiedCIA.NONE);
@@ -1013,6 +1013,29 @@ public class CvssV3_1Test {
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:H", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ModifiedCIA.HIGH, cvssV3_1.getModifiedAvailabilityImpact());
     }
+    
+    @Test
+    public void combinationTest() {
+        Cvss cvss;
+
+        cvss = Cvss.fromVector("CVSS:3.1/AV:A/AC:H/PR:H/UI:R/S:C/C:N/I:H/A:L/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:L");
+        assertEquals(5.9, cvss.calculateScore().getBaseScore(), 0);
+        assertEquals(4.7, cvss.calculateScore().getTemporalScore(), 0);
+        assertEquals(3.7, cvss.calculateScore().getEnvironmentalScore(), 0);
+        assertEquals("CVSS:3.1/AV:A/AC:H/PR:H/UI:R/S:C/C:N/I:H/A:L/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:L", cvss.getVector());
+
+        cvss = Cvss.fromVector("CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:C/C:N/I:H/A:L/E:U/RL:O/RC:U/CR:X/IR:X/AR:X/MAV:X/MAC:X/MPR:X/MUI:X/MS:X/MC:X/MI:X/MA:X");
+        assertEquals(5.8, cvss.calculateScore().getBaseScore(), 0);
+        assertEquals(4.7, cvss.calculateScore().getTemporalScore(), 0);
+        assertEquals(4.7, cvss.calculateScore().getEnvironmentalScore(), 0);
+        assertEquals("CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:C/C:N/I:H/A:L/E:U/RL:O/RC:U", cvss.getVector());
+
+        cvss = Cvss.fromVector("CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:C/C:N/I:H/A:L/E:X/RL:X/RC:X/CR:M/IR:M/AR:X/MAV:A/MAC:X/MPR:X/MUI:X/MS:X/MC:X/MI:X/MA:X");
+        assertEquals(6.2, cvss.calculateScore().getBaseScore(), 0);
+        assertEquals(6.2, cvss.calculateScore().getTemporalScore(), 0);
+        assertEquals(5.9, cvss.calculateScore().getEnvironmentalScore(), 0);
+        assertEquals("CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:C/C:N/I:H/A:L/CR:M/IR:M/MAV:A", cvss.getVector());
+    }
 
     @Test
     public void testRegexPattern() {
@@ -1023,13 +1046,13 @@ public class CvssV3_1Test {
         assertEquals(cvss3Vector, cvssV3.getVector());
 
         // With temporal vector elements
-        cvss3Vector = "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:X/RL:X/RC:C";
+        cvss3Vector = "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:U/RL:U/RC:U";
         cvssV3 = Cvss.fromVector(cvss3Vector);
         Assert.assertNotNull(cvssV3);
         assertEquals(cvss3Vector, cvssV3.getVector());
 
         // With environmental vector elements
-        cvss3Vector = "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:X/RL:X/RC:C/CR:L/IR:M/AR:L/MAV:P/MAC:H/MPR:N/MUI:R/MS:U/MC:L/MI:L/MA:L";
+        cvss3Vector = "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:U/RL:U/RC:U/CR:L/IR:M/AR:L/MAV:P/MAC:H/MPR:N/MUI:R/MS:U/MC:L/MI:L/MA:L";
         cvssV3 = Cvss.fromVector(cvss3Vector);
         Assert.assertNotNull(cvssV3);
         assertEquals(cvss3Vector, cvssV3.getVector());

--- a/src/test/java/us/springett/cvss/CvssV3_1Test.java
+++ b/src/test/java/us/springett/cvss/CvssV3_1Test.java
@@ -69,6 +69,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.AttackVector.NETWORK, cvssV3_1.getAttackVector());
 
         cvssV3_1.attackVector(CvssV3_1.AttackVector.ADJACENT);
@@ -80,6 +82,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.AttackVector.ADJACENT, cvssV3_1.getAttackVector());
 
         cvssV3_1.attackVector(CvssV3_1.AttackVector.LOCAL);
@@ -91,6 +95,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.AttackVector.LOCAL, cvssV3_1.getAttackVector());
 
         cvssV3_1.attackVector(CvssV3_1.AttackVector.PHYSICAL);
@@ -102,6 +108,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.AttackVector.PHYSICAL, cvssV3_1.getAttackVector());
     }
 
@@ -116,6 +124,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.AttackComplexity.LOW, cvssV3_1.getAttackComplexity());
 
         cvssV3_1.attackComplexity(CvssV3_1.AttackComplexity.HIGH);
@@ -127,6 +137,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.AttackComplexity.HIGH, cvssV3_1.getAttackComplexity());
     }
 
@@ -171,6 +183,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3.PrivilegesRequired.NONE, cvssV3_1.getPrivilegesRequired());
 
         cvssV3_1.privilegesRequired(CvssV3.PrivilegesRequired.LOW);
@@ -182,6 +196,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3.PrivilegesRequired.LOW, cvssV3_1.getPrivilegesRequired());
 
         cvssV3_1.privilegesRequired(CvssV3.PrivilegesRequired.HIGH);
@@ -193,6 +209,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3.PrivilegesRequired.HIGH, cvssV3_1.getPrivilegesRequired());
     }
 
@@ -207,6 +225,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.UserInteraction.NONE, cvssV3_1.getUserInteraction());
 
         cvssV3_1.userInteraction(CvssV3_1.UserInteraction.REQUIRED);
@@ -218,6 +238,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.UserInteraction.REQUIRED, cvssV3_1.getUserInteraction());
     }
 
@@ -232,6 +254,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3.Scope.UNCHANGED, cvssV3_1.getScope());
 
         cvssV3_1.scope(CvssV3.Scope.CHANGED);
@@ -243,6 +267,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3.Scope.CHANGED, cvssV3_1.getScope());
     }
 
@@ -257,6 +283,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.CIA.NONE, cvssV3_1.getConfidentiality());
 
         cvssV3_1.confidentiality(CvssV3_1.CIA.LOW);
@@ -268,6 +296,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.CIA.LOW, cvssV3_1.getConfidentiality());
 
         cvssV3_1.confidentiality(CvssV3_1.CIA.HIGH);
@@ -279,6 +309,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.CIA.HIGH, cvssV3_1.getConfidentiality());
     }
 
@@ -293,6 +325,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.CIA.NONE, cvssV3_1.getIntegrity());
 
         cvssV3_1.integrity(CvssV3_1.CIA.LOW);
@@ -304,6 +338,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.CIA.LOW, cvssV3_1.getIntegrity());
 
         cvssV3_1.integrity(CvssV3_1.CIA.HIGH);
@@ -315,6 +351,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.CIA.HIGH, cvssV3_1.getIntegrity());
     }
 
@@ -329,6 +367,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.CIA.NONE, cvssV3_1.getAvailability());
 
         cvssV3_1.availability(CvssV3_1.CIA.LOW);
@@ -340,6 +380,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.CIA.LOW, cvssV3_1.getAvailability());
 
         cvssV3_1.availability(CvssV3_1.CIA.HIGH);
@@ -351,6 +393,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.CIA.HIGH, cvssV3_1.getAvailability());
     }
 
@@ -366,6 +410,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:X/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.Exploitability.NOT_DEFINED, cvssV3_1.getExploitability());
 
         cvssV3_1.exploitability(CvssV3_1.Exploitability.UNPROVEN);
@@ -377,6 +423,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.Exploitability.UNPROVEN, cvssV3_1.getExploitability());
 
         cvssV3_1.exploitability(CvssV3_1.Exploitability.POC);
@@ -388,6 +436,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:P/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:P/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:P/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.Exploitability.POC, cvssV3_1.getExploitability());
 
         cvssV3_1.exploitability(CvssV3_1.Exploitability.FUNCTIONAL);
@@ -399,6 +449,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:F/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:F/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:F/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.Exploitability.FUNCTIONAL, cvssV3_1.getExploitability());
 
         cvssV3_1.exploitability(CvssV3_1.Exploitability.HIGH);
@@ -410,6 +462,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:H/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:H/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:H/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.Exploitability.HIGH, cvssV3_1.getExploitability());
     }
 
@@ -424,6 +478,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:X/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.RemediationLevel.NOT_DEFINED, cvssV3_1.getRemediationLevel());
 
         cvssV3_1.remediationLevel(CvssV3_1.RemediationLevel.OFFICIAL);
@@ -435,6 +491,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.RemediationLevel.OFFICIAL, cvssV3_1.getRemediationLevel());
 
         cvssV3_1.remediationLevel(CvssV3_1.RemediationLevel.TEMPORARY);
@@ -446,6 +504,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:T/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:T/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:T/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.RemediationLevel.TEMPORARY, cvssV3_1.getRemediationLevel());
 
         cvssV3_1.remediationLevel(CvssV3_1.RemediationLevel.WORKAROUND);
@@ -457,6 +517,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:W/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:W/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:W/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.RemediationLevel.WORKAROUND, cvssV3_1.getRemediationLevel());
 
         cvssV3_1.remediationLevel(CvssV3_1.RemediationLevel.UNAVAILABLE);
@@ -468,6 +530,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:U/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:U/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:U/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.RemediationLevel.UNAVAILABLE, cvssV3_1.getRemediationLevel());
     }
 
@@ -482,6 +546,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:X/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ReportConfidence.NOT_DEFINED, cvssV3_1.getReportConfidence());
 
         cvssV3_1.reportConfidence(CvssV3_1.ReportConfidence.UNKNOWN);
@@ -493,6 +559,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ReportConfidence.UNKNOWN, cvssV3_1.getReportConfidence());
 
         cvssV3_1.reportConfidence(CvssV3_1.ReportConfidence.REASONABLE);
@@ -504,6 +572,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:R/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:R/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:R/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ReportConfidence.REASONABLE, cvssV3_1.getReportConfidence());
 
         cvssV3_1.reportConfidence(CvssV3_1.ReportConfidence.CONFIRMED);
@@ -515,6 +585,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:C/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:C/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:C/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ReportConfidence.CONFIRMED, cvssV3_1.getReportConfidence());
     }
 
@@ -530,6 +602,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:X/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ConfidentialityRequirement.NOT_DEFINED, cvssV3_1.getConfidentialityRequirement());
 
         cvssV3_1.confidentialityRequirement(CvssV3_1.ConfidentialityRequirement.LOW);
@@ -541,6 +615,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ConfidentialityRequirement.LOW, cvssV3_1.getConfidentialityRequirement());
 
         cvssV3_1.confidentialityRequirement(CvssV3_1.ConfidentialityRequirement.MEDIUM);
@@ -552,6 +628,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:M/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:M/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:M/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ConfidentialityRequirement.MEDIUM, cvssV3_1.getConfidentialityRequirement());
 
         cvssV3_1.confidentialityRequirement(CvssV3_1.ConfidentialityRequirement.HIGH);
@@ -563,6 +641,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:H/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:H/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:H/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ConfidentialityRequirement.HIGH, cvssV3_1.getConfidentialityRequirement());
     }
 
@@ -577,6 +657,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:X/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.IntegrityRequirement.NOT_DEFINED, cvssV3_1.getIntegrityRequirement());
 
         cvssV3_1.integrityRequirement(CvssV3_1.IntegrityRequirement.LOW);
@@ -588,6 +670,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.IntegrityRequirement.LOW, cvssV3_1.getIntegrityRequirement());
 
         cvssV3_1.integrityRequirement(CvssV3_1.IntegrityRequirement.MEDIUM);
@@ -599,6 +683,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:M/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:M/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:M/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.IntegrityRequirement.MEDIUM, cvssV3_1.getIntegrityRequirement());
 
         cvssV3_1.integrityRequirement(CvssV3_1.IntegrityRequirement.HIGH);
@@ -610,6 +696,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:H/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:H/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:H/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.IntegrityRequirement.HIGH, cvssV3_1.getIntegrityRequirement());
     }
 
@@ -624,6 +712,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:X/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.AvailabilityRequirement.NOT_DEFINED, cvssV3_1.getAvailabilityRequirement());
 
         cvssV3_1.availabilityRequirement(CvssV3_1.AvailabilityRequirement.LOW);
@@ -635,6 +725,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.AvailabilityRequirement.LOW, cvssV3_1.getAvailabilityRequirement());
 
         cvssV3_1.availabilityRequirement(CvssV3_1.AvailabilityRequirement.MEDIUM);
@@ -646,6 +738,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:M/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:M/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:M/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.AvailabilityRequirement.MEDIUM, cvssV3_1.getAvailabilityRequirement());
 
         cvssV3_1.availabilityRequirement(CvssV3_1.AvailabilityRequirement.HIGH);
@@ -657,6 +751,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:H/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:H/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:H/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.AvailabilityRequirement.HIGH, cvssV3_1.getAvailabilityRequirement());
     }
 
@@ -671,6 +767,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:X/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedAttackVector.NOT_DEFINED, cvssV3_1.getModifiedAttackVector());
 
         cvssV3_1.modifiedAttackVector(CvssV3_1.ModifiedAttackVector.NETWORK);
@@ -682,6 +780,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedAttackVector.NETWORK, cvssV3_1.getModifiedAttackVector());
 
         cvssV3_1.modifiedAttackVector(CvssV3_1.ModifiedAttackVector.ADJACENT);
@@ -693,6 +793,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:A/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:A/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:A/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedAttackVector.ADJACENT, cvssV3_1.getModifiedAttackVector());
 
         cvssV3_1.modifiedAttackVector(CvssV3_1.ModifiedAttackVector.LOCAL);
@@ -704,6 +806,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:L/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:L/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:L/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedAttackVector.LOCAL, cvssV3_1.getModifiedAttackVector());
 
         cvssV3_1.modifiedAttackVector(CvssV3_1.ModifiedAttackVector.PHYSICAL);
@@ -715,6 +819,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:P/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:P/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:P/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedAttackVector.PHYSICAL, cvssV3_1.getModifiedAttackVector());
     }
 
@@ -729,6 +835,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:X/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedAttackComplexity.NOT_DEFINED, cvssV3_1.getModifiedAttackComplexity());
 
         cvssV3_1.modifiedAttackComplexity(CvssV3_1.ModifiedAttackComplexity.LOW);
@@ -740,6 +848,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedAttackComplexity.LOW, cvssV3_1.getModifiedAttackComplexity());
 
         cvssV3_1.modifiedAttackComplexity(CvssV3_1.ModifiedAttackComplexity.HIGH);
@@ -751,6 +861,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:H/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:H/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:H/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedAttackComplexity.HIGH, cvssV3_1.getModifiedAttackComplexity());
     }
 
@@ -765,6 +877,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:X/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedPrivilegesRequired.NOT_DEFINED, cvssV3_1.getModifiedPrivilegesRequired());
 
         cvssV3_1.modifiedPrivilegesRequired(CvssV3_1.ModifiedPrivilegesRequired.NONE);
@@ -776,6 +890,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedPrivilegesRequired.NONE, cvssV3_1.getModifiedPrivilegesRequired());
 
         cvssV3_1.modifiedPrivilegesRequired(CvssV3_1.ModifiedPrivilegesRequired.LOW);
@@ -787,6 +903,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:L/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:L/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:L/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedPrivilegesRequired.LOW, cvssV3_1.getModifiedPrivilegesRequired());
 
         cvssV3_1.modifiedPrivilegesRequired(CvssV3_1.ModifiedPrivilegesRequired.HIGH);
@@ -798,6 +916,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:H/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:H/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:H/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedPrivilegesRequired.HIGH, cvssV3_1.getModifiedPrivilegesRequired());
     }
 
@@ -812,6 +932,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:X/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedUserInteraction.NOT_DEFINED, cvssV3_1.getModifiedUserInteraction());
 
         cvssV3_1.modifiedUserInteraction(CvssV3_1.ModifiedUserInteraction.NONE);
@@ -823,6 +945,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedUserInteraction.NONE, cvssV3_1.getModifiedUserInteraction());
 
         cvssV3_1.modifiedUserInteraction(CvssV3_1.ModifiedUserInteraction.REQUIRED);
@@ -834,6 +958,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:R/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:R/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:R/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedUserInteraction.REQUIRED, cvssV3_1.getModifiedUserInteraction());
     }
 
@@ -848,6 +974,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:X/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedScope.NOT_DEFINED, cvssV3_1.getModifiedScope());
 
         cvssV3_1.modifiedScope(CvssV3_1.ModifiedScope.UNCHANGED);
@@ -859,6 +987,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedScope.UNCHANGED, cvssV3_1.getModifiedScope());
 
         cvssV3_1.modifiedScope(CvssV3_1.ModifiedScope.CHANGED);
@@ -870,6 +1000,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:C/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:C/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:C/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedScope.CHANGED, cvssV3_1.getModifiedScope());
     }
 
@@ -884,6 +1016,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:X/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedCIA.NOT_DEFINED, cvssV3_1.getModifiedConfidentialityImpact());
 
         cvssV3_1.modifiedConfidentialityImpact(CvssV3_1.ModifiedCIA.NONE);
@@ -895,6 +1029,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedCIA.NONE, cvssV3_1.getModifiedConfidentialityImpact());
 
         cvssV3_1.modifiedConfidentialityImpact(CvssV3_1.ModifiedCIA.LOW);
@@ -906,6 +1042,8 @@ public class CvssV3_1Test {
         assertEquals(3.7, score.getEnvironmentalScore(), 0);
         assertEquals(0.7, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:L/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:L/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:L/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedCIA.LOW, cvssV3_1.getModifiedConfidentialityImpact());
 
         cvssV3_1.modifiedConfidentialityImpact(CvssV3_1.ModifiedCIA.HIGH);
@@ -917,6 +1055,8 @@ public class CvssV3_1Test {
         assertEquals(4.6, score.getEnvironmentalScore(), 0);
         assertEquals(1.8, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:H/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:H/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:H/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedCIA.HIGH, cvssV3_1.getModifiedConfidentialityImpact());
     }
 
@@ -931,6 +1071,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:X/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedCIA.NOT_DEFINED, cvssV3_1.getModifiedIntegrityImpact());
 
         cvssV3_1.modifiedIntegrityImpact(CvssV3_1.ModifiedCIA.NONE);
@@ -942,6 +1084,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedCIA.NONE, cvssV3_1.getModifiedIntegrityImpact());
 
         cvssV3_1.modifiedIntegrityImpact(CvssV3_1.ModifiedCIA.LOW);
@@ -953,6 +1097,8 @@ public class CvssV3_1Test {
         assertEquals(3.7, score.getEnvironmentalScore(), 0);
         assertEquals(0.7, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:L/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:L/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:L/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedCIA.LOW, cvssV3_1.getModifiedIntegrityImpact());
 
         cvssV3_1.modifiedIntegrityImpact(CvssV3_1.ModifiedCIA.HIGH);
@@ -964,6 +1110,8 @@ public class CvssV3_1Test {
         assertEquals(4.6, score.getEnvironmentalScore(), 0);
         assertEquals(1.8, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:H/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:H/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:H/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedCIA.HIGH, cvssV3_1.getModifiedIntegrityImpact());
     }
 
@@ -978,6 +1126,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:X", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedCIA.NOT_DEFINED, cvssV3_1.getModifiedAvailabilityImpact());
 
         cvssV3_1.modifiedAvailabilityImpact(CvssV3_1.ModifiedCIA.NONE);
@@ -989,6 +1139,8 @@ public class CvssV3_1Test {
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedCIA.NONE, cvssV3_1.getModifiedAvailabilityImpact());
 
         cvssV3_1.modifiedAvailabilityImpact(CvssV3_1.ModifiedCIA.LOW);
@@ -1000,6 +1152,8 @@ public class CvssV3_1Test {
         assertEquals(3.7, score.getEnvironmentalScore(), 0);
         assertEquals(0.7, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:L", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:L", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:L", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedCIA.LOW, cvssV3_1.getModifiedAvailabilityImpact());
 
         cvssV3_1.modifiedAvailabilityImpact(CvssV3_1.ModifiedCIA.HIGH);
@@ -1011,9 +1165,11 @@ public class CvssV3_1Test {
         assertEquals(4.6, score.getEnvironmentalScore(), 0);
         assertEquals(1.8, score.getModifiedImpactSubScore(), 0);
         assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:H", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:H", cvssV3_1.getVector(false));
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:H", cvssV3_1.getVector(true));
         assertEquals(CvssV3_1.ModifiedCIA.HIGH, cvssV3_1.getModifiedAvailabilityImpact());
     }
-    
+
     @Test
     public void combinationTest() {
         Cvss cvss;


### PR DESCRIPTION
* fixed environmental score calculation by using base score values if the environmental score values are null or `NOT_DEFINED` ("X") -> otherwise the environmental score is zero if not all fields are set 
* updated `getVector()` method to only return vector fields that have a value assigned (all `NOT_DEFINED` fields are removed from the vector string)
* added check for negative values (invalid, use zero instead)
* updated/added tests

the changes are based on the cvss-calculator script from first.org (https://www.first.org/cvss/calculator/cvsscalc31.js)