### PR TITLE
Improve Cvss.from() parsing performance

### DIFF
--- a/src/main/java/us/springett/cvss/CvssV2.java
+++ b/src/main/java/us/springett/cvss/CvssV2.java
@@ -92,7 +92,7 @@ public class CvssV2 implements Cvss {
         }
         public static AttackVector fromString(String text) {
             for (AttackVector e : AttackVector.values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }
@@ -113,7 +113,7 @@ public class CvssV2 implements Cvss {
         }
         public static AttackComplexity fromString(String text) {
             for (AttackComplexity e : AttackComplexity.values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }
@@ -134,7 +134,7 @@ public class CvssV2 implements Cvss {
         }
         public static Authentication fromString(String text) {
             for (Authentication e : Authentication.values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }
@@ -158,7 +158,7 @@ public class CvssV2 implements Cvss {
         }
         public static Exploitability fromString(String text) {
             for (Exploitability e : Exploitability.values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }
@@ -181,7 +181,7 @@ public class CvssV2 implements Cvss {
         }
         public static RemediationLevel  fromString(String text) {
             for (RemediationLevel  e : RemediationLevel .values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }
@@ -203,7 +203,7 @@ public class CvssV2 implements Cvss {
         }
         public static ReportConfidence  fromString(String text) {
             for (ReportConfidence  e : ReportConfidence .values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }
@@ -225,7 +225,7 @@ public class CvssV2 implements Cvss {
         }
         public static CIA fromString(String text) {
             for (CIA e : CIA.values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }

--- a/src/main/java/us/springett/cvss/CvssV3.java
+++ b/src/main/java/us/springett/cvss/CvssV3.java
@@ -108,7 +108,7 @@ public class CvssV3 implements Cvss {
         }
         public static AttackVector fromString(String text) {
             for (AttackVector e : AttackVector.values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }
@@ -128,7 +128,7 @@ public class CvssV3 implements Cvss {
         }
         public static AttackComplexity fromString(String text) {
             for (AttackComplexity e : AttackComplexity.values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }
@@ -151,7 +151,7 @@ public class CvssV3 implements Cvss {
         }
         public static PrivilegesRequired fromString(String text) {
             for (PrivilegesRequired e : PrivilegesRequired.values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }
@@ -171,7 +171,7 @@ public class CvssV3 implements Cvss {
         }
         public static UserInteraction fromString(String text) {
             for (UserInteraction e : UserInteraction.values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }
@@ -191,7 +191,7 @@ public class CvssV3 implements Cvss {
         }
         public static Scope fromString(String text) {
             for (Scope e : Scope.values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }
@@ -215,7 +215,7 @@ public class CvssV3 implements Cvss {
         }
         public static Exploitability fromString(String text) {
             for (Exploitability e : Exploitability.values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }
@@ -238,7 +238,7 @@ public class CvssV3 implements Cvss {
         }
         public static RemediationLevel fromString(String text) {
             for (RemediationLevel e : RemediationLevel.values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }
@@ -260,7 +260,7 @@ public class CvssV3 implements Cvss {
         }
         public static ReportConfidence fromString(String text) {
             for (ReportConfidence e : ReportConfidence.values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }
@@ -282,7 +282,7 @@ public class CvssV3 implements Cvss {
         }
         public static CIA fromString(String text) {
             for (CIA e : CIA.values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }

--- a/src/main/java/us/springett/cvss/CvssV3_1.java
+++ b/src/main/java/us/springett/cvss/CvssV3_1.java
@@ -304,7 +304,7 @@ public class CvssV3_1 extends CvssV3 {
 
         public static ConfidentialityRequirement fromString(String text) {
             for (ConfidentialityRequirement cr : ConfidentialityRequirement.values()) {
-                if (cr.shorthand.equalsIgnoreCase(text)) {
+                if (cr.shorthand.equals(text)) {
                     return cr;
                 }
             }
@@ -328,7 +328,7 @@ public class CvssV3_1 extends CvssV3 {
 
         public static IntegrityRequirement fromString(String text) {
             for (IntegrityRequirement ir : IntegrityRequirement.values()) {
-                if (ir.shorthand.equalsIgnoreCase(text)) {
+                if (ir.shorthand.equals(text)) {
                     return ir;
                 }
             }
@@ -352,7 +352,7 @@ public class CvssV3_1 extends CvssV3 {
 
         public static AvailabilityRequirement fromString(String text) {
             for (AvailabilityRequirement ar : AvailabilityRequirement.values()) {
-                if (ar.shorthand.equalsIgnoreCase(text)) {
+                if (ar.shorthand.equals(text)) {
                     return ar;
                 }
             }
@@ -377,7 +377,7 @@ public class CvssV3_1 extends CvssV3 {
 
         public static ModifiedAttackVector fromString(String text) {
             for (ModifiedAttackVector e : ModifiedAttackVector.values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }
@@ -400,7 +400,7 @@ public class CvssV3_1 extends CvssV3 {
 
         public static ModifiedAttackComplexity fromString(String text) {
             for (ModifiedAttackComplexity e : ModifiedAttackComplexity.values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }
@@ -426,7 +426,7 @@ public class CvssV3_1 extends CvssV3 {
 
         public static ModifiedPrivilegesRequired fromString(String text) {
             for (ModifiedPrivilegesRequired e : ModifiedPrivilegesRequired.values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }
@@ -449,7 +449,7 @@ public class CvssV3_1 extends CvssV3 {
 
         public static ModifiedUserInteraction fromString(String text) {
             for (ModifiedUserInteraction e : ModifiedUserInteraction.values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }
@@ -472,7 +472,7 @@ public class CvssV3_1 extends CvssV3 {
 
         public static ModifiedScope fromString(String text) {
             for (ModifiedScope e : ModifiedScope.values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }
@@ -496,7 +496,7 @@ public class CvssV3_1 extends CvssV3 {
 
         public static ModifiedCIA fromString(String text) {
             for (ModifiedCIA e : ModifiedCIA.values()) {
-                if (e.shorthand.equalsIgnoreCase(text)) {
+                if (e.shorthand.equals(text)) {
                     return e;
                 }
             }

--- a/src/test/java/us/springett/cvss/CvssV3_1Test.java
+++ b/src/test/java/us/springett/cvss/CvssV3_1Test.java
@@ -1020,18 +1020,62 @@ public class CvssV3_1Test {
         String cvss3Vector = "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H";
         Cvss cvssV3 = Cvss.fromVector(cvss3Vector);
         Assert.assertNotNull(cvssV3);
+        CvssV3 v3 = (CvssV3)cvssV3;
+        Assert.assertEquals(CvssV3.AttackVector.NETWORK, v3.getAttackVector());
+        Assert.assertEquals(CvssV3.AttackComplexity.LOW, v3.getAttackComplexity());
+        Assert.assertEquals(CvssV3.PrivilegesRequired.HIGH, v3.getPrivilegesRequired());
+        Assert.assertEquals(CvssV3.UserInteraction.NONE, v3.getUserInteraction());
+        Assert.assertEquals(CvssV3.Scope.UNCHANGED, v3.getScope());
+        Assert.assertEquals(CvssV3.CIA.HIGH, v3.getConfidentiality());
+        Assert.assertEquals(CvssV3.CIA.HIGH, v3.getIntegrity());
+        Assert.assertEquals(CvssV3.CIA.HIGH, v3.getAvailability());
         assertEquals(cvss3Vector, cvssV3.getVector());
 
         // With temporal vector elements
-        cvss3Vector = "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:X/RL:X/RC:C";
+        cvss3Vector = "CVSS:3.0/AV:A/AC:H/PR:L/UI:R/S:C/C:L/I:H/A:L/E:X/RL:X/RC:C";
         cvssV3 = Cvss.fromVector(cvss3Vector);
         Assert.assertNotNull(cvssV3);
+        v3 = (CvssV3)cvssV3;
+        Assert.assertEquals(CvssV3.AttackVector.ADJACENT, v3.getAttackVector());
+        Assert.assertEquals(CvssV3.AttackComplexity.HIGH, v3.getAttackComplexity());
+        Assert.assertEquals(CvssV3.PrivilegesRequired.LOW, v3.getPrivilegesRequired());
+        Assert.assertEquals(CvssV3.UserInteraction.REQUIRED, v3.getUserInteraction());
+        Assert.assertEquals(CvssV3.Scope.CHANGED, v3.getScope());
+        Assert.assertEquals(CvssV3.CIA.LOW, v3.getConfidentiality());
+        Assert.assertEquals(CvssV3.CIA.HIGH, v3.getIntegrity());
+        Assert.assertEquals(CvssV3.CIA.LOW, v3.getAvailability());
+        Assert.assertEquals(CvssV3.Exploitability.NOT_DEFINED, v3.getExploitability());
+        Assert.assertEquals(CvssV3.RemediationLevel.NOT_DEFINED, v3.getRemediationLevel());
+        Assert.assertEquals(CvssV3.ReportConfidence.CONFIRMED, v3.getReportConfidence());
         assertEquals(cvss3Vector, cvssV3.getVector());
 
         // With environmental vector elements
-        cvss3Vector = "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:X/RL:X/RC:C/CR:L/IR:M/AR:L/MAV:P/MAC:H/MPR:N/MUI:R/MS:U/MC:L/MI:L/MA:L";
+        cvss3Vector = "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:U/RL:T/RC:R/CR:L/IR:M/AR:L/MAV:P/MAC:H/MPR:N/MUI:R/MS:U/MC:L/MI:L/MA:L";
         cvssV3 = Cvss.fromVector(cvss3Vector);
         Assert.assertNotNull(cvssV3);
+        CvssV3_1 v3_1 = (CvssV3_1)cvssV3;
+        Assert.assertEquals(CvssV3.AttackVector.NETWORK, v3_1.getAttackVector());
+        Assert.assertEquals(CvssV3.AttackComplexity.LOW, v3_1.getAttackComplexity());
+        Assert.assertEquals(CvssV3.PrivilegesRequired.HIGH, v3_1.getPrivilegesRequired());
+        Assert.assertEquals(CvssV3.UserInteraction.NONE, v3_1.getUserInteraction());
+        Assert.assertEquals(CvssV3.Scope.UNCHANGED, v3_1.getScope());
+        Assert.assertEquals(CvssV3.CIA.HIGH, v3_1.getConfidentiality());
+        Assert.assertEquals(CvssV3.CIA.HIGH, v3_1.getIntegrity());
+        Assert.assertEquals(CvssV3.CIA.HIGH, v3_1.getAvailability());
+        Assert.assertEquals(CvssV3.Exploitability.UNPROVEN, v3_1.getExploitability());
+        Assert.assertEquals(CvssV3.RemediationLevel.TEMPORARY, v3_1.getRemediationLevel());
+        Assert.assertEquals(CvssV3.ReportConfidence.REASONABLE, v3_1.getReportConfidence());
+        Assert.assertEquals(CvssV3_1.ConfidentialityRequirement.LOW, v3_1.getConfidentialityRequirement());
+        Assert.assertEquals(CvssV3_1.IntegrityRequirement.MEDIUM, v3_1.getIntegrityRequirement());
+        Assert.assertEquals(CvssV3_1.AvailabilityRequirement.LOW, v3_1.getAvailabilityRequirement());
+        Assert.assertEquals(CvssV3_1.ModifiedAttackVector.PHYSICAL, v3_1.getModifiedAttackVector());
+        Assert.assertEquals(CvssV3_1.ModifiedAttackComplexity.HIGH, v3_1.getModifiedAttackComplexity());
+        Assert.assertEquals(CvssV3_1.ModifiedPrivilegesRequired.NONE, v3_1.getModifiedPrivilegesRequired());
+        Assert.assertEquals(CvssV3_1.ModifiedUserInteraction.REQUIRED, v3_1.getModifiedUserInteraction());
+        Assert.assertEquals(CvssV3_1.ModifiedScope.UNCHANGED, v3_1.getModifiedScope());
+        Assert.assertEquals(CvssV3_1.ModifiedCIA.LOW, v3_1.getModifiedConfidentialityImpact());
+        Assert.assertEquals(CvssV3_1.ModifiedCIA.LOW, v3_1.getModifiedIntegrityImpact());
+        Assert.assertEquals(CvssV3_1.ModifiedCIA.LOW, v3_1.getModifiedAvailabilityImpact());
         assertEquals(cvss3Vector, cvssV3.getVector());
     }
 }


### PR DESCRIPTION
**What does it do?**

Improve parsing performance by optimizing several parts:

- Use regex groups to do the parsing (that we are doing anyway) to avoid have to use StringTokenizer + split
- Use equals in enums instead of equalsIgnoreCase as it is already impossible based on the regexes
- Do not use all the regexes at the same time (at the initial part of the method) and reorder them based on the probability of success (V3 more likely that V2).

The performance was measured with a JMH test that I did not push, but that I could if it can be interesting

**Update**

There is an improvement made on top of this PR [here](https://github.com/stevespringett/cvss-calculator/compare/master...anderruiz:cvss-calculator:ander.ruiz/char_based_improvements), that basically replace the usage of String (whenever possible) by chars which ends in a faster parsing and serialization (getVector). I also included additional test for the parsing part. I would vote for using the char based one, but we can split it in two different PRs if needed