### PR TITLE
Refactor parsing to fix v3 / v3.1 detection, and handle unordered metrics

### DIFF
--- a/src/main/java/us/springett/cvss/Cvss.java
+++ b/src/main/java/us/springett/cvss/Cvss.java
@@ -15,9 +15,6 @@
  */
 package us.springett.cvss;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 /**
  * Defines an interface for CVSS versions.
  *
@@ -25,19 +22,6 @@ import java.util.regex.Pattern;
  * @since 1.0.0
  */
 public interface Cvss {
-
-    String V2_PATTERN = "AV:(N|A|L)\\/AC:(L|M|H)\\/A[Uu]:(N|S|M)\\/C:(N|P|C)\\/I:(N|P|C)\\/A:(N|P|C)";
-    String V2_TEMPORAL = "\\/E:\\b(F|H|U|POC|ND)\\b\\/RL:\\b(W|U|TF|OF|ND)\\b\\/RC:\\b(C|UR|UC|ND)\\b";
-
-    String V3_PATTERN = "AV:(N|A|L|P)\\/AC:(L|H)\\/PR:(N|L|H)\\/UI:(N|R)\\/S:(U|C)\\/C:(N|L|H)\\/I:(N|L|H)\\/A:(N|L|H)";
-    String V3_TEMPORAL = "\\/E:(F|H|U|P|X)\\/RL:(W|U|T|O|X)\\/RC:(C|R|U|X)";
-    String V3_1_ENVIRONMENTAL = "\\/CR:(X|L|M|H)\\/IR:(X|L|M|H)\\/AR:(X|L|M|H)\\/MAV:(X|N|A|L|P)\\/MAC:(X|L|H)\\/MPR:(X|N|L|H)\\/MUI:(X|N|R)\\/MS:(X|U|C)\\/MC:(X|N|L|H)\\/MI:(X|N|L|H)\\/MA:(X|N|L|H)";
-
-    Pattern CVSSv2_PATTERN = Pattern.compile(V2_PATTERN);
-    Pattern CVSSv2_PATTERN_TEMPORAL = Pattern.compile(V2_PATTERN + V2_TEMPORAL);
-    Pattern CVSSv3_PATTERN = Pattern.compile(V3_PATTERN);
-    Pattern CVSSv3_PATTERN_TEMPORAL = Pattern.compile(V3_PATTERN + V3_TEMPORAL);
-    Pattern CVSSv3_1_PATTERN = Pattern.compile(V3_PATTERN + V3_TEMPORAL + V3_1_ENVIRONMENTAL);
 
     /**
      * A factory method which accepts a String representation of a
@@ -47,6 +31,7 @@ public interface Cvss {
      *
      * @param vector the CVSS vector to parse
      * @return a Cvss object
+     * @throws MalformedVectorException When the provided vector is invalid
      * @since 1.1.0
      */
     static Cvss fromVector(String vector) {
@@ -54,97 +39,17 @@ public interface Cvss {
             return null;
         }
 
-        Matcher v3_1Matcher = CVSSv3_1_PATTERN.matcher(vector);
-        if (v3_1Matcher.find()) {
-            // Found a valid CVSSv3.1 vector
-            char [] vectorChars = vector.toCharArray();
-            CvssV3_1 cvssV3_1 = getCvssV3_1BaseVector(v3_1Matcher, vectorChars);
-            fillV3TemporalValues(v3_1Matcher, vectorChars, cvssV3_1);
-            cvssV3_1.confidentialityRequirement(CvssV3_1.ConfidentialityRequirement.fromChar(vectorChars[v3_1Matcher.start(12)]));
-            cvssV3_1.integrityRequirement(CvssV3_1.IntegrityRequirement.fromChar(vectorChars[v3_1Matcher.start(13)]));
-            cvssV3_1.availabilityRequirement(CvssV3_1.AvailabilityRequirement.fromChar(vectorChars[v3_1Matcher.start(14)]));
-            cvssV3_1.modifiedAttackVector(CvssV3_1.ModifiedAttackVector.fromChar(vectorChars[v3_1Matcher.start(15)]));
-            cvssV3_1.modifiedAttackComplexity(CvssV3_1.ModifiedAttackComplexity.fromChar(vectorChars[v3_1Matcher.start(16)]));
-            cvssV3_1.modifiedPrivilegesRequired(CvssV3_1.ModifiedPrivilegesRequired.fromChar(vectorChars[v3_1Matcher.start(17)]));
-            cvssV3_1.modifiedUserInteraction(CvssV3_1.ModifiedUserInteraction.fromChar(vectorChars[v3_1Matcher.start(18)]));
-            cvssV3_1.modifiedScope(CvssV3_1.ModifiedScope.fromChar(vectorChars[v3_1Matcher.start(19)]));
-            cvssV3_1.modifiedConfidentialityImpact(CvssV3_1.ModifiedCIA.fromChar(vectorChars[v3_1Matcher.start(20)]));
-            cvssV3_1.modifiedIntegrityImpact(CvssV3_1.ModifiedCIA.fromChar(vectorChars[v3_1Matcher.start(21)]));
-            cvssV3_1.modifiedAvailabilityImpact(CvssV3_1.ModifiedCIA.fromChar(vectorChars[v3_1Matcher.start(22)]));
-            return cvssV3_1;
+        final Parser<? extends Cvss> parser;
+        if (vector.startsWith(CvssV3_1.VECTOR_PREFIX)) {
+            parser = new CvssV3_1.Parser();
+            return parser.parseVector(vector);
+        } else if (vector.startsWith(CvssV3.VECTOR_PREFIX)) {
+            parser = new CvssV3.Parser();
+            return parser.parseVector(vector);
+        } else {
+            parser = new CvssV2.Parser();
+            return parser.parseVector(vector);
         }
-        Matcher v3TemporalMatcher = CVSSv3_PATTERN_TEMPORAL.matcher(vector);
-        if (v3TemporalMatcher.find()) {
-            char [] vectorChars = vector.toCharArray();
-            // Found a valid CVSSv3 vector with temporal values
-            CvssV3 cvssV3 = getCvssV3BaseVector(v3TemporalMatcher, vectorChars);
-            fillV3TemporalValues(v3TemporalMatcher, vectorChars, cvssV3);
-            return cvssV3;
-        }
-        Matcher v3Matcher = CVSSv3_PATTERN.matcher(vector);
-        if (v3Matcher.find()) {
-            char [] vectorChars = vector.toCharArray();
-            // Found a valid CVSSv3 vector
-            return getCvssV3BaseVector(v3Matcher, vectorChars);
-        }
-        Matcher v2TemporalMatcher = CVSSv2_PATTERN_TEMPORAL.matcher(vector);
-        if (v2TemporalMatcher.find()) {
-            // Found a valid CVSSv2 vector with temporal values
-            CvssV2 cvssV2 = getCvssV2BaseVector(v2TemporalMatcher, vector.toCharArray());
-            cvssV2.exploitability(CvssV2.Exploitability.fromString(v2TemporalMatcher.group(7)));
-            cvssV2.remediationLevel(CvssV2.RemediationLevel.fromString(v2TemporalMatcher.group(8)));
-            cvssV2.reportConfidence(CvssV2.ReportConfidence.fromString(v2TemporalMatcher.group(9)));
-            return cvssV2;
-        }
-        Matcher v2Matcher = CVSSv2_PATTERN.matcher(vector);
-        if (v2Matcher.find()) {
-            // Found a valid CVSSv2 vector
-            return getCvssV2BaseVector(v2Matcher, vector.toCharArray());
-        } else
-        return null;
-    }
-
-    static void fillV3TemporalValues(Matcher v3TemporalMatcher, char[] vectorChars, CvssV3 cvssV3) {
-        cvssV3.exploitability(CvssV3.Exploitability.fromChar(vectorChars[v3TemporalMatcher.start(9)]));
-        cvssV3.remediationLevel(CvssV3.RemediationLevel.fromChar(vectorChars[v3TemporalMatcher.start(10)]));
-        cvssV3.reportConfidence(CvssV3.ReportConfidence.fromChar(vectorChars[v3TemporalMatcher.start(11)]));
-    }
-
-    static CvssV2 getCvssV2BaseVector(Matcher st, char [] array) {
-        CvssV2 cvssV2 = new CvssV2();
-        cvssV2.attackVector(CvssV2.AttackVector.fromChar(array[st.start(1)]));
-        cvssV2.attackComplexity(CvssV2.AttackComplexity.fromChar(array[st.start(2)]));
-        cvssV2.authentication(CvssV2.Authentication.fromChar(array[st.start(3)]));
-        cvssV2.confidentiality(CvssV2.CIA.fromChar(array[st.start(4)]));
-        cvssV2.integrity(CvssV2.CIA.fromChar(array[st.start(5)]));
-        cvssV2.availability(CvssV2.CIA.fromChar(array[st.start(6)]));
-        return cvssV2;
-    }
-
-    static CvssV3 getCvssV3BaseVector(Matcher st, char [] array) {
-        CvssV3 cvssV3 = new CvssV3();
-        cvssV3.attackVector(CvssV3.AttackVector.fromChar(array[st.start(1)]));
-        cvssV3.attackComplexity(CvssV3.AttackComplexity.fromChar(array[st.start(2)]));
-        cvssV3.privilegesRequired(CvssV3.PrivilegesRequired.fromChar(array[st.start(3)]));
-        cvssV3.userInteraction(CvssV3.UserInteraction.fromChar(array[st.start(4)]));
-        cvssV3.scope(CvssV3.Scope.fromChar(array[st.start(5)]));
-        cvssV3.confidentiality(CvssV3.CIA.fromString(array[st.start(6)]));
-        cvssV3.integrity(CvssV3.CIA.fromString(array[st.start(7)]));
-        cvssV3.availability(CvssV3.CIA.fromString(array[st.start(8)]));
-        return cvssV3;
-    }
-
-    static CvssV3_1 getCvssV3_1BaseVector(Matcher st, char [] array) {
-        CvssV3_1 cvssV3_1 = new CvssV3_1();
-        cvssV3_1.attackVector(CvssV3.AttackVector.fromChar(array[st.start(1)]));
-        cvssV3_1.attackComplexity(CvssV3.AttackComplexity.fromChar(array[st.start(2)]));
-        cvssV3_1.privilegesRequired(CvssV3.PrivilegesRequired.fromChar(array[st.start(3)]));
-        cvssV3_1.userInteraction(CvssV3.UserInteraction.fromChar(array[st.start(4)]));
-        cvssV3_1.scope(CvssV3.Scope.fromChar(array[st.start(5)]));
-        cvssV3_1.confidentiality(CvssV3.CIA.fromString(array[st.start(6)]));
-        cvssV3_1.integrity(CvssV3.CIA.fromString(array[st.start(7)]));
-        cvssV3_1.availability(CvssV3.CIA.fromString(array[st.start(8)]));
-        return cvssV3_1;
     }
 
     /**

--- a/src/main/java/us/springett/cvss/CvssV2.java
+++ b/src/main/java/us/springett/cvss/CvssV2.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -36,55 +37,55 @@ public class CvssV2 implements Cvss {
     private AttackVector av;
     private AttackComplexity ac;
     private Authentication au;
-    private Exploitability e;
-    private RemediationLevel rl;
-    private ReportConfidence rc;
+    private Exploitability e = Exploitability.NOT_DEFINED;
+    private RemediationLevel rl = RemediationLevel.NOT_DEFINED;
+    private ReportConfidence rc = ReportConfidence.NOT_DEFINED;
     private CIA c;
     private CIA i;
     private CIA a;
 
     public CvssV2 attackVector(AttackVector av) {
-        this.av = av;
+        this.av = Objects.requireNonNull(av);
         return this;
     }
 
     public CvssV2 attackComplexity(AttackComplexity ac) {
-        this.ac = ac;
+        this.ac = Objects.requireNonNull(ac);
         return this;
     }
 
     public CvssV2 authentication(Authentication au) {
-        this.au = au;
+        this.au = Objects.requireNonNull(au);
         return this;
     }
 
     public CvssV2 confidentiality(CIA c) {
-        this.c = c;
+        this.c = Objects.requireNonNull(c);
         return this;
     }
 
     public CvssV2 integrity(CIA i) {
-        this.i = i;
+        this.i = Objects.requireNonNull(i);
         return this;
     }
 
     public CvssV2 availability(CIA a) {
-        this.a = a;
+        this.a = Objects.requireNonNull(a);
         return this;
     }
 
     public CvssV2 exploitability(Exploitability e) {
-        this.e = e;
+        this.e = Objects.requireNonNull(e);
         return this;
     }
 
     public CvssV2 remediationLevel(RemediationLevel rl) {
-        this.rl = rl;
+        this.rl = Objects.requireNonNull(rl);
         return this;
     }
 
     public CvssV2 reportConfidence(ReportConfidence rc) {
-        this.rc = rc;
+        this.rc = Objects.requireNonNull(rc);
         return this;
     }
 
@@ -380,13 +381,13 @@ public class CvssV2 implements Cvss {
                 "A:" + a.shorthand
         ));
 
-        if (e != null) {
+        if (e != Exploitability.NOT_DEFINED) {
             vectorParts.add("E:" + e.shorthand);
         }
-        if (rl != null) {
+        if (rl != RemediationLevel.NOT_DEFINED) {
             vectorParts.add("RL:" + rl.shorthand);
         }
-        if (rc != null) {
+        if (rc != ReportConfidence.NOT_DEFINED) {
             vectorParts.add("RC:" + rc.shorthand);
         }
 

--- a/src/main/java/us/springett/cvss/CvssV2.java
+++ b/src/main/java/us/springett/cvss/CvssV2.java
@@ -15,6 +15,15 @@
  */
 package us.springett.cvss;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static us.springett.cvss.Parser.requireNonNull;
+
 /**
  * Calculates CVSSv2 scores and vector.
  *
@@ -233,6 +242,99 @@ public class CvssV2 implements Cvss {
         }
     }
 
+    static final class Parser implements us.springett.cvss.Parser<CvssV2> {
+
+        private static final List<String> MANDATORY_METRICS = Arrays.asList(
+                "AV", "AC", "Au", "C", "I", "A" // Base metrics.
+        );
+
+        @Override
+        public CvssV2 parseVector(String vector) {
+            if (vector == null || vector.isEmpty()) {
+                throw new MalformedVectorException("Vector must not be null or empty");
+            }
+
+            vector = vector.replaceAll("^\\(|\\)$", "");
+
+            final String[] segments = vector.split("/");
+            if (segments.length < MANDATORY_METRICS.size()) {
+                throw new MalformedVectorException(String.format(
+                        "Vector must consist of at least %d segments (mandatory metrics %s), but has only %s",
+                        MANDATORY_METRICS.size(), String.join(", ", MANDATORY_METRICS), segments.length
+                ));
+            }
+
+            final CvssV2 cvss = new CvssV2();
+            final Set<String> metricsSeen = new HashSet<>();
+            for (int i = 0; i < segments.length; i++) {
+                final String[] metricParts = segments[i].split(":", 2);
+                if (metricParts.length < 2) {
+                    throw new MalformedVectorException(String.format(
+                            "Segment #%d is malformed; Expected format <METRIC>:<VALUE>, but got \"%s\"",
+                            (i + 1), segments[i]
+                    ));
+                }
+
+                final String metric = metricParts[0];
+                final char metricValue = metricParts[1].charAt(0);
+
+                switch (metric) {
+                    // Base.
+                    case "AV":
+                        cvss.attackVector(requireNonNull(metric, metricValue, AttackVector::fromChar));
+                        break;
+                    case "AC":
+                        cvss.attackComplexity(requireNonNull(metric, metricValue, AttackComplexity::fromChar));
+                        break;
+                    case "Au":
+                        cvss.authentication(requireNonNull(metric, metricValue, Authentication::fromChar));
+                        break;
+                    case "C":
+                        cvss.confidentiality(requireNonNull(metric, metricValue, CIA::fromChar));
+                        break;
+                    case "I":
+                        cvss.integrity(requireNonNull(metric, metricValue, CIA::fromChar));
+                        break;
+                    case "A":
+                        cvss.availability(requireNonNull(metric, metricValue, CIA::fromChar));
+                        break;
+                    // Temporal.
+                    case "E":
+                        cvss.exploitability(requireNonNull(metric, metricParts[1], Exploitability::fromString));
+                        break;
+                    case "RL":
+                        cvss.remediationLevel(requireNonNull(metric, metricParts[1], RemediationLevel::fromString));
+                        break;
+                    case "RC":
+                        cvss.reportConfidence(requireNonNull(metric, metricParts[1], ReportConfidence::fromString));
+                        break;
+                    // Environmental.
+                    case "CDP":
+                    case "TD":
+                    case "CR":
+                    case "IR":
+                    case "AR":
+                        // TODO: Handle these.
+                        break;
+                    default:
+                        throw new MalformedVectorException("Unknown metric: " + metric);
+                }
+
+                metricsSeen.add(metric);
+            }
+
+            final List<String> missingMetrics = MANDATORY_METRICS.stream()
+                    .filter(metric -> !metricsSeen.contains(metric))
+                    .collect(Collectors.toList());
+            if (!missingMetrics.isEmpty()) {
+                throw new MalformedVectorException("Missing mandatory metrics: " + String.join(", ", missingMetrics));
+            }
+
+            return cvss;
+        }
+
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -269,17 +371,26 @@ public class CvssV2 implements Cvss {
      * {@inheritDoc}
      */
     public String getVector() {
-        return "(" +
-                "AV:" + av.shorthand + "/" +
-                "AC:" + ac.shorthand + "/" +
-                "Au:" + au.shorthand + "/" +
-                "C:" + c.shorthand + "/" +
-                "I:" + i.shorthand + "/" +
-                "A:" + a.shorthand +
-                ((e != null && rl != null && rc != null) ? (
-                        "/E:" + e.shorthand + "/" +
-                        "RL:" + rl.shorthand + "/" +
-                        "RC:" + rc.shorthand + ")") : ")");
+        final List<String> vectorParts = new ArrayList<>(Arrays.asList(
+                "AV:" + av.shorthand,
+                "AC:" + ac.shorthand,
+                "Au:" + au.shorthand,
+                "C:" + c.shorthand,
+                "I:" + i.shorthand,
+                "A:" + a.shorthand
+        ));
+
+        if (e != null) {
+            vectorParts.add("E:" + e.shorthand);
+        }
+        if (rl != null) {
+            vectorParts.add("RL:" + rl.shorthand);
+        }
+        if (rc != null) {
+            vectorParts.add("RC:" + rc.shorthand);
+        }
+
+        return "(" + String.join("/", vectorParts) + ")";
     }
 
     public AttackVector getAttackVector() {

--- a/src/main/java/us/springett/cvss/CvssV3.java
+++ b/src/main/java/us/springett/cvss/CvssV3.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -43,65 +44,65 @@ public class CvssV3 implements Cvss {
     protected PrivilegesRequired pr;
     protected UserInteraction ui;
     protected Scope s;
-    protected Exploitability e;
-    protected RemediationLevel rl;
-    protected ReportConfidence rc;
+    protected Exploitability e = Exploitability.NOT_DEFINED;
+    protected RemediationLevel rl = RemediationLevel.NOT_DEFINED;
+    protected ReportConfidence rc = ReportConfidence.NOT_DEFINED;
     protected CIA c;
     protected CIA i;
     protected CIA a;
 
     public CvssV3 attackVector(AttackVector av) {
-        this.av = av;
+        this.av = Objects.requireNonNull(av);
         return this;
     }
 
     public CvssV3 attackComplexity(AttackComplexity ac) {
-        this.ac = ac;
+        this.ac = Objects.requireNonNull(ac);
         return this;
     }
 
     public CvssV3 privilegesRequired(PrivilegesRequired pr) {
-        this.pr = pr;
+        this.pr = Objects.requireNonNull(pr);
         return this;
     }
 
     public CvssV3 userInteraction(UserInteraction ui) {
-        this.ui = ui;
+        this.ui = Objects.requireNonNull(ui);
         return this;
     }
 
     public CvssV3 scope(Scope s) {
-        this.s = s;
+        this.s = Objects.requireNonNull(s);
         return this;
     }
 
     public CvssV3 confidentiality(CIA c) {
-        this.c = c;
+        this.c = Objects.requireNonNull(c);
         return this;
     }
 
     public CvssV3 integrity(CIA i) {
-        this.i = i;
+        this.i = Objects.requireNonNull(i);
         return this;
     }
 
     public CvssV3 availability(CIA a) {
-        this.a = a;
+        this.a = Objects.requireNonNull(a);
         return this;
     }
 
     public CvssV3 exploitability(Exploitability e) {
-        this.e = e;
+        this.e = Objects.requireNonNull(e);
         return this;
     }
 
     public CvssV3 remediationLevel(RemediationLevel rl) {
-        this.rl = rl;
+        this.rl = Objects.requireNonNull(rl);
         return this;
     }
 
     public CvssV3 reportConfidence(ReportConfidence rc) {
-        this.rc = rc;
+        this.rc = Objects.requireNonNull(rc);
         return this;
     }
 
@@ -473,13 +474,13 @@ public class CvssV3 implements Cvss {
                 "A:" + a.shorthand
         ));
 
-        if (e != null) {
+        if (e != Exploitability.NOT_DEFINED) {
             vectorParts.add("E:" + e.shorthand);
         }
-        if (rl != null) {
+        if (rl != RemediationLevel.NOT_DEFINED) {
             vectorParts.add("RL:" + rl.shorthand);
         }
-        if (rc != null) {
+        if (rc != ReportConfidence.NOT_DEFINED) {
             vectorParts.add("RC:" + rc.shorthand);
         }
 

--- a/src/main/java/us/springett/cvss/CvssV3_1.java
+++ b/src/main/java/us/springett/cvss/CvssV3_1.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -14,126 +15,137 @@ public class CvssV3_1 extends CvssV3 {
     static final String VECTOR_PREFIX = "CVSS:3.1";
 
     /**** Environmental Score Metric Group ****/
-    protected ModifiedAttackVector mav;
-    protected ModifiedAttackComplexity mac;
-    protected ModifiedPrivilegesRequired mpr;
-    protected ModifiedUserInteraction mui;
-    protected ModifiedScope ms;
-    protected ModifiedCIA mc;
-    protected ModifiedCIA mi;
-    protected ModifiedCIA ma;
+    protected ModifiedAttackVector mav = ModifiedAttackVector.NOT_DEFINED;
+    protected ModifiedAttackComplexity mac = ModifiedAttackComplexity.NOT_DEFINED;
+    protected ModifiedPrivilegesRequired mpr = ModifiedPrivilegesRequired.NOT_DEFINED;
+    protected ModifiedUserInteraction mui = ModifiedUserInteraction.NOT_DEFINED;
+    protected ModifiedScope ms = ModifiedScope.NOT_DEFINED;
+    protected ModifiedCIA mc = ModifiedCIA.NOT_DEFINED;
+    protected ModifiedCIA mi = ModifiedCIA.NOT_DEFINED;
+    protected ModifiedCIA ma = ModifiedCIA.NOT_DEFINED;
 
-    protected ConfidentialityRequirement cr;
-    protected IntegrityRequirement ir;
-    protected AvailabilityRequirement ar;
+    protected ConfidentialityRequirement cr = ConfidentialityRequirement.NOT_DEFINED;
+    protected IntegrityRequirement ir = IntegrityRequirement.NOT_DEFINED;
+    protected AvailabilityRequirement ar = AvailabilityRequirement.NOT_DEFINED;
 
+    @Override
     public CvssV3_1 attackVector(AttackVector av) {
-        this.av = av;
+        this.av = Objects.requireNonNull(av);
         return this;
     }
 
+    @Override
     public CvssV3_1 attackComplexity(AttackComplexity ac) {
-        this.ac = ac;
+        this.ac = Objects.requireNonNull(ac);
         return this;
     }
 
+    @Override
     public CvssV3_1 privilegesRequired(PrivilegesRequired pr) {
-        this.pr = pr;
+        this.pr = Objects.requireNonNull(pr);
         return this;
     }
 
+    @Override
     public CvssV3_1 userInteraction(UserInteraction ui) {
-        this.ui = ui;
+        this.ui = Objects.requireNonNull(ui);
         return this;
     }
 
+    @Override
     public CvssV3_1 scope(Scope s) {
-        this.s = s;
+        this.s = Objects.requireNonNull(s);
         return this;
     }
 
+    @Override
     public CvssV3_1 confidentiality(CIA c) {
-        this.c = c;
+        this.c = Objects.requireNonNull(c);
         return this;
     }
 
+    @Override
     public CvssV3_1 integrity(CIA i) {
-        this.i = i;
+        this.i = Objects.requireNonNull(i);
         return this;
     }
 
+    @Override
     public CvssV3_1 availability(CIA a) {
-        this.a = a;
+        this.a = Objects.requireNonNull(a);
         return this;
     }
 
+    @Override
     public CvssV3_1 exploitability(Exploitability e) {
-        this.e = e;
+        this.e = Objects.requireNonNull(e);
         return this;
     }
 
+    @Override
     public CvssV3_1 remediationLevel(RemediationLevel rl) {
-        this.rl = rl;
+        this.rl = Objects.requireNonNull(rl);
         return this;
     }
 
+    @Override
     public CvssV3_1 reportConfidence(ReportConfidence rc) {
-        this.rc = rc;
+        this.rc = Objects.requireNonNull(rc);
         return this;
     }
 
     public CvssV3_1 confidentialityRequirement(ConfidentialityRequirement cr) {
-        this.cr = cr;
+        this.cr = Objects.requireNonNull(cr);
         return this;
     }
 
     public CvssV3_1 integrityRequirement(IntegrityRequirement ir) {
-        this.ir = ir;
+        this.ir = Objects.requireNonNull(ir);
         return this;
     }
 
     public CvssV3_1 availabilityRequirement(AvailabilityRequirement ar) {
-        this.ar = ar;
+        this.ar = Objects.requireNonNull(ar);
         return this;
     }
 
     public CvssV3_1 modifiedAttackVector(ModifiedAttackVector mav) {
-        this.mav = mav;
+        this.mav = Objects.requireNonNull(mav);
         return this;
     }
 
     public CvssV3_1 modifiedAttackComplexity(ModifiedAttackComplexity mac) {
-        this.mac = mac;
+        this.mac = Objects.requireNonNull(mac);
         return this;
     }
 
     public CvssV3_1 modifiedPrivilegesRequired(ModifiedPrivilegesRequired mpr) {
-        this.mpr = mpr;
+        this.mpr = Objects.requireNonNull(mpr);
         return this;
     }
 
     public CvssV3_1 modifiedUserInteraction(ModifiedUserInteraction mui) {
-        this.mui = mui;
+        this.mui = Objects.requireNonNull(mui);
         return this;
     }
 
     public CvssV3_1 modifiedScope(ModifiedScope ms) {
-        this.ms = ms;
+        this.ms = Objects.requireNonNull(ms);
         return this;
     }
 
     public CvssV3_1 modifiedConfidentialityImpact(ModifiedCIA mc) {
-        this.mc = mc;
+        this.mc = Objects.requireNonNull(mc);
         return this;
     }
 
     public CvssV3_1 modifiedIntegrityImpact(ModifiedCIA mi) {
-        this.mi = mi;
+        this.mi = Objects.requireNonNull(mi);
         return this;
     }
 
     public CvssV3_1 modifiedAvailabilityImpact(ModifiedCIA ma) {
-        this.ma = ma;
+        this.ma = Objects.requireNonNull(ma);
         return this;
     }
 
@@ -240,47 +252,47 @@ public class CvssV3_1 extends CvssV3 {
                 "A:" + a.shorthand
         ));
 
-        if (e != null) {
+        if (e != Exploitability.NOT_DEFINED) {
             vectorParts.add("E:" + e.shorthand);
         }
-        if (rl != null) {
+        if (rl != RemediationLevel.NOT_DEFINED) {
             vectorParts.add("RL:" + rl.shorthand);
         }
-        if (rc != null) {
+        if (rc != ReportConfidence.NOT_DEFINED) {
             vectorParts.add("RC:" + rc.shorthand);
         }
 
-        if (cr != null) {
+        if (cr != ConfidentialityRequirement.NOT_DEFINED) {
             vectorParts.add("CR:" + cr.shorthand);
         }
-        if (ir != null) {
+        if (ir != IntegrityRequirement.NOT_DEFINED) {
             vectorParts.add("IR:" + ir.shorthand);
         }
-        if (ar != null) {
+        if (ar != AvailabilityRequirement.NOT_DEFINED) {
             vectorParts.add("AR:" + ar.shorthand);
         }
-        if (mav != null) {
+        if (mav != ModifiedAttackVector.NOT_DEFINED) {
             vectorParts.add("MAV:" + mav.shorthand);
         }
-        if (mac != null) {
+        if (mac != ModifiedAttackComplexity.NOT_DEFINED) {
             vectorParts.add("MAC:" + mac.shorthand);
         }
-        if (mpr != null) {
+        if (mpr != ModifiedPrivilegesRequired.NOT_DEFINED) {
             vectorParts.add("MPR:" + mpr.shorthand);
         }
-        if (mui != null) {
+        if (mui != ModifiedUserInteraction.NOT_DEFINED) {
             vectorParts.add("MUI:" + mui.shorthand);
         }
-        if (ms != null) {
+        if (ms != ModifiedScope.NOT_DEFINED) {
             vectorParts.add("MS:" + ms.shorthand);
         }
-        if (mc != null) {
+        if (mc != ModifiedCIA.NOT_DEFINED) {
             vectorParts.add("MC:" + mc.shorthand);
         }
-        if (mi != null) {
+        if (mi != ModifiedCIA.NOT_DEFINED) {
             vectorParts.add("MI:" + mi.shorthand);
         }
-        if (ma != null) {
+        if (ma != ModifiedCIA.NOT_DEFINED) {
             vectorParts.add("MA:" + ma.shorthand);
         }
 

--- a/src/main/java/us/springett/cvss/MalformedVectorException.java
+++ b/src/main/java/us/springett/cvss/MalformedVectorException.java
@@ -1,0 +1,24 @@
+/*
+ * This file is part of the CVSS Calculator.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package us.springett.cvss;
+
+public class MalformedVectorException extends RuntimeException {
+
+    MalformedVectorException(final String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/us/springett/cvss/Parser.java
+++ b/src/main/java/us/springett/cvss/Parser.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the CVSS Calculator.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package us.springett.cvss;
+
+import java.util.function.Function;
+
+interface Parser<T extends Cvss> {
+
+    T parseVector(String vector);
+
+    static <E extends Enum<?>> E requireNonNull(final String metric, final char value, final Function<Character, E> function) {
+        final E result = function.apply(value);
+        if (result == null) {
+            throw new MalformedVectorException("Invalid value for metric " + metric + ": " + value);
+        }
+
+        return result;
+    }
+
+    static <E extends Enum<?>> E requireNonNull(final String metric, final String value, final Function<String, E> function) {
+        final E result = function.apply(value);
+        if (result == null) {
+            throw new MalformedVectorException("Invalid value for metric " + metric + ": " + value);
+        }
+
+        return result;
+    }
+
+}

--- a/src/test/java/us/springett/cvss/CvssFromVectorTest.java
+++ b/src/test/java/us/springett/cvss/CvssFromVectorTest.java
@@ -147,6 +147,14 @@ public class CvssFromVectorTest {
             }
 
             try {
+                // Sanity check; Calculation should never fail when parsing succeeded.
+                cvss.calculateScore();
+            } catch (RuntimeException e) {
+                Assert.fail("Expected #calculateScore to not fail, but it failed with: " + e.getMessage());
+            }
+
+            try {
+                // Sanity check; Vector construction should never fail when parsing succeeded.
                 cvss.getVector();
             } catch (RuntimeException e) {
                 Assert.fail("Expected #getVector invocation to not fail, but it failed with: " + e.getMessage());

--- a/src/test/java/us/springett/cvss/CvssFromVectorTest.java
+++ b/src/test/java/us/springett/cvss/CvssFromVectorTest.java
@@ -1,0 +1,213 @@
+/*
+ * This file is part of the CVSS Calculator.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package us.springett.cvss;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static us.springett.cvss.CvssFromVectorTest.FailureExpectation.expectFailure;
+import static us.springett.cvss.CvssFromVectorTest.SuccessExpectation.expectSuccess;
+
+@RunWith(Parameterized.class)
+public class CvssFromVectorTest {
+
+    @Parameters(name = "{index}: vector={0} expectation={1}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                // Invalid empty vector
+                {"", expectFailure().withMessage("Vector must not be null or empty")},
+                // ---
+                // CVSSv2
+                // ---
+                // Valid CVSSv2 vector without parentheses
+                {"AV:N/AC:H/Au:N/C:P/I:N/A:N", expectSuccess().withClass(CvssV2.class)},
+                // Valid CVSSv2 vector without opening parenthesis
+                {"AV:N/AC:H/Au:N/C:P/I:N/A:N)", expectSuccess().withClass(CvssV2.class)},
+                // Valid CVSSv2 vector without closing parenthesis
+                {"(AV:N/AC:H/Au:N/C:P/I:N/A:N", expectSuccess().withClass(CvssV2.class)},
+                // Valid CVSSv2 vector with parentheses
+                {"(AV:N/AC:H/Au:N/C:P/I:N/A:N)", expectSuccess().withClass(CvssV2.class)},
+                // Valid CVSSv2 vector with temporal metrics
+                {"(AV:N/AC:H/Au:N/C:P/I:N/A:N/E:POC/RL:ND/RC:UC)", expectSuccess().withClass(CvssV2.class)},
+                // Valid CVSSv2 vector with environmental metrics
+                {"(AV:N/AC:H/Au:N/C:P/I:N/A:N/CDP:N/TD:L/CR:M/IR:H/AR:L)", expectSuccess().withClass(CvssV2.class)},
+                // Valid CVSSv2 vector with temporal and environmental metrics
+                {"(AV:N/AC:H/Au:N/C:P/I:N/A:N/E:POC/RL:ND/RC:UC/CDP:N/TD:L/CR:M/IR:H/AR:L)", expectSuccess().withClass(CvssV2.class)},
+                // Non-strict ordering of metrics; Ordering is not enforced
+                {"(AC:H/AV:N/Au:N/C:P/I:N/A:N)", expectSuccess().withClass(CvssV2.class)},
+                // Invalid CVSSv2 vector with missing segments
+                {"(AV:N/AC:H/Au:N/C:P/I:N)", expectFailure().withMessage("Vector must consist of at least 6 segments (mandatory metrics AV, AC, Au, C, I, A), but has only 5")},
+                // Invalid CVSSv2 vector with missing mandatory metric
+                {"(AV:N/AC:H/Au:N/C:P/I:N/E:POC)", expectFailure().withMessage("Missing mandatory metrics: A")},
+                // Invalid CVSSv2 vector with unknown metric
+                {"(AV:N/AC:H/Au:N/C:P/I:N/X:X)", expectFailure().withMessage("Unknown metric: X")},
+                // Invalid CVSSv2 vector with malformed segment
+                {"(AV:N/AC:H/Au:N/C:P/I:N/A:N/foobar)", expectFailure().withMessage("Segment #7 is malformed; Expected format <METRIC>:<VALUE>, but got \"foobar\"")},
+                // Invalid CVSSv2 vector with invalid metric value
+                {"(AV:N/AC:H/Au:Z/C:P/I:N/A:N)", expectFailure().withMessage("Invalid value for metric Au: Z")},
+                // ---
+                // CVSSv3.0
+                // ---
+                // Valid CVSSv3.0 vector with base metrics
+                {"CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H", expectSuccess().withClass(CvssV3.class)},
+                // Valid CVSSv3.0 vector with temporal metrics
+                {"CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:T/RC:C", expectSuccess().withClass(CvssV3.class)},
+                // Valid CVSSv3.0 vector with environmental metrics
+                {"CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/CR:L/IR:M/AR:M/MAV:A/MAC:H/MPR:N/MUI:R/MS:U/MI:H/MA:L", expectSuccess().withClass(CvssV3.class)},
+                // Valid CVSSv3.0 vector with temporal and environmental metrics
+                {"CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:T/RC:C/CR:L/IR:M/AR:M/MAV:A/MAC:H/MPR:N/MUI:R/MS:U/MI:H/MA:L", expectSuccess().withClass(CvssV3.class)},
+                // Non-strict ordering of metrics; Ordering must not be enforced for CVSSv3
+                {"CVSS:3.0/AC:H/AV:N/A:H/C:H/I:H/PR:N/S:U/UI:N", expectSuccess().withClass(CvssV3.class)},
+                // Invalid CVSSv3.0 vector with missing segments
+                {"CVSS:3.0/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H", expectFailure().withMessage("Vector must consist of at least 9 segments (CVSS:3.0 prefix and mandatory metrics AV, AC, PR, UI, S, C, I, A), but has only 8")},
+                // Invalid CVSSv3.0 vector with missing mandatory metric
+                {"CVSS:3.0/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:U", expectFailure().withMessage("Missing mandatory metrics: AV")},
+                // Invalid CVSSv3.0 vector with unknown metric
+                {"CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/X:X", expectFailure().withMessage("Unknown metric: X")},
+                // Invalid CVSSv3.0 vector with malformed segment
+                {"CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/foobar", expectFailure().withMessage("Segment #10 is malformed; Expected format <METRIC>:<VALUE>, but got \"foobar\"")},
+                // Invalid CVSSv3.0 vector with invalid metric value
+                {"CVSS:3.0/AV:N/AC:L/PR:X/UI:N/S:U/C:H/I:H/A:H", expectFailure().withMessage("Invalid value for metric PR: X")},
+                // ---
+                // CVSSv3.1
+                // ---
+                {"CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H", expectSuccess().withClass(CvssV3_1.class)},
+                // Valid CVSSv3.1 vector with temporal metrics
+                {"CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:T/RC:C", expectSuccess().withClass(CvssV3_1.class)},
+                // Valid CVSSv3.1 vector with environmental metrics
+                {"CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/CR:L/IR:M/AR:M/MAV:A/MAC:H/MPR:N/MUI:R/MS:U/MI:H/MA:L", expectSuccess().withClass(CvssV3_1.class)},
+                // Valid CVSSv3.1 vector with temporal and environmental metrics
+                {"CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:T/RC:C/CR:L/IR:M/AR:M/MAV:A/MAC:H/MPR:N/MUI:R/MS:U/MI:H/MA:L", expectSuccess().withClass(CvssV3_1.class)},
+                // Non-strict ordering of metrics; Ordering must not be enforced for CVSSv3.1
+                {"CVSS:3.1/AC:H/AV:N/A:H/C:H/I:H/PR:N/S:U/UI:N", expectSuccess().withClass(CvssV3_1.class)},
+                // Invalid CVSSv3.1 vector with missing segments
+                {"CVSS:3.1/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H", expectFailure().withMessage("Vector must consist of at least 9 segments (CVSS:3.1 prefix and mandatory metrics AV, AC, PR, UI, S, C, I, A), but has only 8")},
+                // Invalid CVSSv3.1 vector with missing mandatory metric
+                {"CVSS:3.1/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:U", expectFailure().withMessage("Missing mandatory metrics: AV")},
+                // Invalid CVSSv3.1 vector with unknown metric
+                {"CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/X:X", expectFailure().withMessage("Unknown metric: X")},
+                // Invalid CVSSv3.1 vector with malformed segment
+                {"CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/foobar", expectFailure().withMessage("Segment #10 is malformed; Expected format <METRIC>:<VALUE>, but got \"foobar\"")},
+                // Invalid CVSSv3.1 vector with invalid metric value
+                {"CVSS:3.1/AV:N/AC:L/PR:X/UI:N/S:U/C:H/I:H/A:H", expectFailure().withMessage("Invalid value for metric PR: X")},
+
+        });
+    }
+
+    public interface Expectation {
+
+        void evaluate(String vector);
+
+    }
+
+    static final class SuccessExpectation implements Expectation {
+
+        private Class<? extends Cvss> cvssClass;
+
+        static SuccessExpectation expectSuccess() {
+            return new SuccessExpectation();
+        }
+
+        private SuccessExpectation withClass(final Class<? extends Cvss> cvssClass) {
+            this.cvssClass = cvssClass;
+            return this;
+        }
+
+        @Override
+        public void evaluate(final String vector) {
+            final Cvss cvss;
+            try {
+                cvss = Cvss.fromVector(vector);
+            } catch (RuntimeException e) {
+                Assert.fail("Expected parsing to not fail, but it failed with: " + e.getMessage());
+                return;
+            }
+
+            if (cvssClass != null) {
+                Assert.assertEquals(cvssClass, cvss.getClass());
+            }
+
+            try {
+                cvss.getVector();
+            } catch (RuntimeException e) {
+                Assert.fail("Expected #getVector invocation to not fail, but it failed with: " + e.getMessage());
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "Success";
+        }
+
+    }
+
+    static final class FailureExpectation implements Expectation {
+
+        private String message;
+
+        static FailureExpectation expectFailure() {
+            return new FailureExpectation();
+        }
+
+        private FailureExpectation withMessage(final String message) {
+            this.message = message;
+            return this;
+        }
+
+        @Override
+        public void evaluate(final String vector) {
+            RuntimeException exception = null;
+            try {
+                Cvss.fromVector(vector);
+            } catch (RuntimeException e) {
+                exception = e;
+            }
+
+            Assert.assertNotNull("Expected parsing to fail, but it did not", exception);
+            Assert.assertEquals(MalformedVectorException.class, exception.getClass());
+
+            if (message != null) {
+                Assert.assertEquals(message, exception.getMessage());
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "Failure";
+        }
+
+    }
+
+    private final String vector;
+    private final Expectation expectation;
+
+    public CvssFromVectorTest(final String vector, final Expectation expectation) {
+        this.vector = vector;
+        this.expectation = expectation;
+    }
+
+    @Test
+    public void test() {
+        expectation.evaluate(vector);
+    }
+
+}

--- a/src/test/java/us/springett/cvss/CvssV2Test.java
+++ b/src/test/java/us/springett/cvss/CvssV2Test.java
@@ -251,7 +251,7 @@ public class CvssV2Test {
         Assert.assertEquals(2.9, score.getImpactSubScore(), 0);
         Assert.assertEquals(4.9, score.getExploitabilitySubScore(), 0);
         Assert.assertEquals(2.5, score.getTemporalScore(), 0);
-        Assert.assertEquals(null, "(AV:N/AC:H/Au:N/C:P/I:N/A:N/E:ND/RL:W/RC:C)", cvssV2Temporal.getVector());
+        Assert.assertEquals(null, "(AV:N/AC:H/Au:N/C:P/I:N/A:N/RL:W/RC:C)", cvssV2Temporal.getVector());
         Assert.assertEquals(CvssV2.Exploitability.NOT_DEFINED, cvssV2Temporal.getExploitability());
     }
 
@@ -298,7 +298,7 @@ public class CvssV2Test {
         Assert.assertEquals(2.9, score.getImpactSubScore(), 0);
         Assert.assertEquals(4.9, score.getExploitabilitySubScore(), 0);
         Assert.assertEquals(2.5, score.getTemporalScore(), 0);
-        Assert.assertEquals(null, "(AV:N/AC:H/Au:N/C:P/I:N/A:N/E:F/RL:ND/RC:C)", cvssV2Temporal.getVector());
+        Assert.assertEquals(null, "(AV:N/AC:H/Au:N/C:P/I:N/A:N/E:F/RC:C)", cvssV2Temporal.getVector());
         Assert.assertEquals(CvssV2.RemediationLevel.NOT_DEFINED, cvssV2Temporal.getRemediationLevel());
     }
 
@@ -336,7 +336,7 @@ public class CvssV2Test {
         Assert.assertEquals(2.9, score.getImpactSubScore(), 0);
         Assert.assertEquals(4.9, score.getExploitabilitySubScore(), 0);
         Assert.assertEquals(2.3, score.getTemporalScore(), 0);
-        Assert.assertEquals(null, "(AV:N/AC:H/Au:N/C:P/I:N/A:N/E:F/RL:W/RC:ND)", cvssV2Temporal.getVector());
+        Assert.assertEquals(null, "(AV:N/AC:H/Au:N/C:P/I:N/A:N/E:F/RL:W)", cvssV2Temporal.getVector());
         Assert.assertEquals(CvssV2.ReportConfidence.NOT_DEFINED, cvssV2Temporal.getReportConfidence());
     }
 
@@ -352,6 +352,17 @@ public class CvssV2Test {
         cvss2Vector = "(AV:N/AC:H/Au:N/C:P/I:N/A:N/E:F/RL:W/RC:ND)";
         cvssV2 = Cvss.fromVector(cvss2Vector);
         Assert.assertNotNull(cvssV2);
-        Assert.assertEquals(cvss2Vector, cvssV2.getVector());
+        Assert.assertEquals("(AV:N/AC:H/Au:N/C:P/I:N/A:N/E:F/RL:W)", cvssV2.getVector());
     }
+
+    @Test
+    public void testTemporalScoreWithPartiallyProvidedMetrics() {
+        final Cvss cvss = Cvss.fromVector("(AV:N/AC:H/Au:N/C:P/I:N/A:N/E:F)");
+        final Score score = cvss.calculateScore();
+
+        Assert.assertEquals(2.6, score.getBaseScore(), 0);
+        Assert.assertEquals(2.5, score.getTemporalScore(), 0);
+        Assert.assertEquals(-1.0, score.getEnvironmentalScore(), 0); // TODO: Should be 2.5 (https://github.com/stevespringett/cvss-calculator/issues/66)
+    }
+
 }

--- a/src/test/java/us/springett/cvss/CvssV3Test.java
+++ b/src/test/java/us/springett/cvss/CvssV3Test.java
@@ -266,7 +266,7 @@ public class CvssV3Test {
         Assert.assertEquals(5.9, score.getImpactSubScore(), 0);
         Assert.assertEquals(1.2, score.getExploitabilitySubScore(), 0);
         Assert.assertEquals(7.2, score.getTemporalScore(), 0);
-        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:X/RL:X/RC:X", cvssV3.getVector());
+        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H", cvssV3.getVector());
         Assert.assertEquals(CvssV3.Exploitability.NOT_DEFINED, cvssV3.getExploitability());
 
         cvssV3.exploitability(CvssV3.Exploitability.UNPROVEN);
@@ -275,7 +275,7 @@ public class CvssV3Test {
         Assert.assertEquals(5.9, score.getImpactSubScore(), 0);
         Assert.assertEquals(1.2, score.getExploitabilitySubScore(), 0);
         Assert.assertEquals(6.6, score.getTemporalScore(), 0);
-        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:U/RL:X/RC:X", cvssV3.getVector());
+        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:U", cvssV3.getVector());
         Assert.assertEquals(CvssV3.Exploitability.UNPROVEN, cvssV3.getExploitability());
 
         cvssV3.exploitability(CvssV3.Exploitability.POC);
@@ -284,7 +284,7 @@ public class CvssV3Test {
         Assert.assertEquals(5.9, score.getImpactSubScore(), 0);
         Assert.assertEquals(1.2, score.getExploitabilitySubScore(), 0);
         Assert.assertEquals(6.8, score.getTemporalScore(), 0);
-        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:P/RL:X/RC:X", cvssV3.getVector());
+        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:P", cvssV3.getVector());
         Assert.assertEquals(CvssV3.Exploitability.POC, cvssV3.getExploitability());
 
         cvssV3.exploitability(CvssV3.Exploitability.FUNCTIONAL);
@@ -293,7 +293,7 @@ public class CvssV3Test {
         Assert.assertEquals(5.9, score.getImpactSubScore(), 0);
         Assert.assertEquals(1.2, score.getExploitabilitySubScore(), 0);
         Assert.assertEquals(7.0, score.getTemporalScore(), 0);
-        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:F/RL:X/RC:X", cvssV3.getVector());
+        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:F", cvssV3.getVector());
         Assert.assertEquals(CvssV3.Exploitability.FUNCTIONAL, cvssV3.getExploitability());
 
         cvssV3.exploitability(CvssV3.Exploitability.HIGH);
@@ -302,7 +302,7 @@ public class CvssV3Test {
         Assert.assertEquals(5.9, score.getImpactSubScore(), 0);
         Assert.assertEquals(1.2, score.getExploitabilitySubScore(), 0);
         Assert.assertEquals(7.2, score.getTemporalScore(), 0);
-        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:H/RL:X/RC:X", cvssV3.getVector());
+        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:H", cvssV3.getVector());
         Assert.assertEquals(CvssV3.Exploitability.HIGH, cvssV3.getExploitability());
     }
 
@@ -317,7 +317,7 @@ public class CvssV3Test {
         Assert.assertEquals(5.9, score.getImpactSubScore(), 0);
         Assert.assertEquals(1.2, score.getExploitabilitySubScore(), 0);
         Assert.assertEquals(6.9, score.getTemporalScore(), 0);
-        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:X/RL:O/RC:X", cvssV3.getVector());
+        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/RL:O", cvssV3.getVector());
         Assert.assertEquals(CvssV3.RemediationLevel.OFFICIAL, cvssV3.getRemediationLevel());
 
         cvssV3.remediationLevel(CvssV3.RemediationLevel.TEMPORARY);
@@ -326,7 +326,7 @@ public class CvssV3Test {
         Assert.assertEquals(5.9, score.getImpactSubScore(), 0);
         Assert.assertEquals(1.2, score.getExploitabilitySubScore(), 0);
         Assert.assertEquals(7.0, score.getTemporalScore(), 0);
-        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:X/RL:T/RC:X", cvssV3.getVector());
+        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/RL:T", cvssV3.getVector());
         Assert.assertEquals(CvssV3.RemediationLevel.TEMPORARY, cvssV3.getRemediationLevel());
 
         cvssV3.remediationLevel(CvssV3.RemediationLevel.WORKAROUND);
@@ -335,7 +335,7 @@ public class CvssV3Test {
         Assert.assertEquals(5.9, score.getImpactSubScore(), 0);
         Assert.assertEquals(1.2, score.getExploitabilitySubScore(), 0);
         Assert.assertEquals(7.0, score.getTemporalScore(), 0);
-        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:X/RL:W/RC:X", cvssV3.getVector());
+        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/RL:W", cvssV3.getVector());
         Assert.assertEquals(CvssV3.RemediationLevel.WORKAROUND, cvssV3.getRemediationLevel());
 
         cvssV3.remediationLevel(CvssV3.RemediationLevel.UNAVAILABLE);
@@ -344,7 +344,7 @@ public class CvssV3Test {
         Assert.assertEquals(5.9, score.getImpactSubScore(), 0);
         Assert.assertEquals(1.2, score.getExploitabilitySubScore(), 0);
         Assert.assertEquals(7.2, score.getTemporalScore(), 0);
-        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:X/RL:U/RC:X", cvssV3.getVector());
+        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/RL:U", cvssV3.getVector());
         Assert.assertEquals(CvssV3.RemediationLevel.UNAVAILABLE, cvssV3.getRemediationLevel());
     }
 
@@ -359,7 +359,7 @@ public class CvssV3Test {
         Assert.assertEquals(5.9, score.getImpactSubScore(), 0);
         Assert.assertEquals(1.2, score.getExploitabilitySubScore(), 0);
         Assert.assertEquals(6.7, score.getTemporalScore(), 0);
-        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:X/RL:X/RC:U", cvssV3.getVector());
+        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/RC:U", cvssV3.getVector());
         Assert.assertEquals(CvssV3.ReportConfidence.UNKNOWN, cvssV3.getReportConfidence());
 
         cvssV3.reportConfidence(CvssV3.ReportConfidence.REASONABLE);
@@ -368,7 +368,7 @@ public class CvssV3Test {
         Assert.assertEquals(5.9, score.getImpactSubScore(), 0);
         Assert.assertEquals(1.2, score.getExploitabilitySubScore(), 0);
         Assert.assertEquals(7.0, score.getTemporalScore(), 0);
-        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:X/RL:X/RC:R", cvssV3.getVector());
+        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/RC:R", cvssV3.getVector());
         Assert.assertEquals(CvssV3.ReportConfidence.REASONABLE, cvssV3.getReportConfidence());
 
         cvssV3.reportConfidence(CvssV3.ReportConfidence.CONFIRMED);
@@ -377,7 +377,7 @@ public class CvssV3Test {
         Assert.assertEquals(5.9, score.getImpactSubScore(), 0);
         Assert.assertEquals(1.2, score.getExploitabilitySubScore(), 0);
         Assert.assertEquals(7.2, score.getTemporalScore(), 0);
-        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:X/RL:X/RC:C", cvssV3.getVector());
+        Assert.assertEquals(null, "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/RC:C", cvssV3.getVector());
         Assert.assertEquals(CvssV3.ReportConfidence.CONFIRMED, cvssV3.getReportConfidence());
     }
 
@@ -393,6 +393,17 @@ public class CvssV3Test {
         cvss3Vector = "CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:X/RL:X/RC:C";
         cvssV3 = Cvss.fromVector(cvss3Vector);
         Assert.assertNotNull(cvssV3);
-        Assert.assertEquals(cvss3Vector, cvssV3.getVector());
+        Assert.assertEquals("CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/RC:C", cvssV3.getVector());
     }
+
+    @Test
+    public void testTemporalScoreWithPartiallyProvidedMetrics() {
+        final Cvss cvss = Cvss.fromVector("CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L/E:F");
+        final Score score = cvss.calculateScore();
+
+        Assert.assertEquals(7.6, score.getBaseScore(), 0);
+        Assert.assertEquals(7.4, score.getTemporalScore(), 0);
+        Assert.assertEquals(-1.0, score.getEnvironmentalScore(), 0); // TODO: Should be 7.4 (https://github.com/stevespringett/cvss-calculator/issues/66)
+    }
+
 }

--- a/src/test/java/us/springett/cvss/CvssV3_1NotDefinedRegression.java
+++ b/src/test/java/us/springett/cvss/CvssV3_1NotDefinedRegression.java
@@ -16,7 +16,7 @@ public class CvssV3_1NotDefinedRegression {
 
         double environmentalScore = vector.calculateScore().getEnvironmentalScore();
 
-        assertEquals("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H/E:X/RL:X/RC:X/CR:X/IR:H/AR:H/MAV:A/MAC:H/MPR:H/MUI:X/MS:U/MC:H/MI:H/MA:H", vector.getVector());
+        assertEquals("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H/IR:H/AR:H/MAV:A/MAC:H/MPR:H/MS:U/MC:H/MI:H/MA:H", vector.getVector());
         assertEquals(6.4, environmentalScore, 0.01);
     }
 
@@ -31,7 +31,7 @@ public class CvssV3_1NotDefinedRegression {
 
         double environmentalScore = vector.calculateScore().getEnvironmentalScore();
 
-        assertEquals("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H/E:X/RL:X/RC:X/CR:X/IR:H/AR:H/MAV:A/MAC:H/MPR:X/MUI:N/MS:U/MC:H/MI:H/MA:H", vector.getVector());
+        assertEquals("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H/IR:H/AR:H/MAV:A/MAC:H/MUI:N/MS:U/MC:H/MI:H/MA:H", vector.getVector());
         assertEquals(7.5, environmentalScore, 0.01);
     }
 
@@ -46,7 +46,7 @@ public class CvssV3_1NotDefinedRegression {
 
         double environmentalScore = vector.calculateScore().getEnvironmentalScore();
 
-        assertEquals("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H/E:X/RL:X/RC:X/CR:X/IR:H/AR:H/MAV:A/MAC:X/MPR:N/MUI:N/MS:U/MC:H/MI:H/MA:H", vector.getVector());
+        assertEquals("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H/IR:H/AR:H/MAV:A/MPR:N/MUI:N/MS:U/MC:H/MI:H/MA:H", vector.getVector());
         assertEquals(7.5, environmentalScore, 0.01);
     }
 
@@ -61,7 +61,7 @@ public class CvssV3_1NotDefinedRegression {
 
         double environmentalScore = vector.calculateScore().getEnvironmentalScore();
 
-        assertEquals("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H/E:X/RL:X/RC:X/CR:X/IR:H/AR:H/MAV:X/MAC:H/MPR:N/MUI:N/MS:U/MC:H/MI:H/MA:H", vector.getVector());
+        assertEquals("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H/IR:H/AR:H/MAC:H/MPR:N/MUI:N/MS:U/MC:H/MI:H/MA:H", vector.getVector());
         assertEquals(8.1, environmentalScore, 0.01);
     }
 
@@ -77,7 +77,7 @@ public class CvssV3_1NotDefinedRegression {
 
         double environmentalScore = vector.calculateScore().getEnvironmentalScore();
 
-        assertEquals(vectorString, vector.getVector());
+        assertEquals("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H/IR:H/AR:H/MAV:A/MAC:H/MPR:N/MUI:N/MC:H/MI:H/MA:H", vector.getVector());
         assertEquals(7.5, environmentalScore, 0.01);
     }
 
@@ -88,7 +88,7 @@ public class CvssV3_1NotDefinedRegression {
 
         double environmentalScore = vector.calculateScore().getEnvironmentalScore();
 
-        assertEquals(vectorString, vector.getVector());
+        assertEquals("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H/IR:H/AR:H/MAV:A/MAC:H/MPR:N/MUI:N/MS:U/MI:H/MA:H", vector.getVector());
         assertEquals(7.5, environmentalScore, 0.01);
     }
 
@@ -99,7 +99,7 @@ public class CvssV3_1NotDefinedRegression {
 
         double environmentalScore = vector.calculateScore().getEnvironmentalScore();
 
-        assertEquals(vectorString, vector.getVector());
+        assertEquals("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H/IR:H/AR:H/MAV:A/MAC:H/MPR:N/MUI:N/MS:U/MC:H/MA:H", vector.getVector());
         assertEquals(7.5, environmentalScore, 0.01);
     }
 
@@ -110,7 +110,7 @@ public class CvssV3_1NotDefinedRegression {
 
         double environmentalScore = vector.calculateScore().getEnvironmentalScore();
 
-        assertEquals(vectorString, vector.getVector());
+        assertEquals("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H/IR:H/AR:H/MAV:A/MAC:H/MPR:N/MUI:N/MS:U/MC:H/MI:H", vector.getVector());
         assertEquals(7.5, environmentalScore, 0.01);
     }
 }

--- a/src/test/java/us/springett/cvss/CvssV3_1Test.java
+++ b/src/test/java/us/springett/cvss/CvssV3_1Test.java
@@ -365,7 +365,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:X/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.Exploitability.NOT_DEFINED, cvssV3_1.getExploitability());
 
         cvssV3_1.exploitability(CvssV3_1.Exploitability.UNPROVEN);
@@ -423,7 +423,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:X/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.RemediationLevel.NOT_DEFINED, cvssV3_1.getRemediationLevel());
 
         cvssV3_1.remediationLevel(CvssV3_1.RemediationLevel.OFFICIAL);
@@ -481,7 +481,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:X/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ReportConfidence.NOT_DEFINED, cvssV3_1.getReportConfidence());
 
         cvssV3_1.reportConfidence(CvssV3_1.ReportConfidence.UNKNOWN);
@@ -529,7 +529,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:X/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ConfidentialityRequirement.NOT_DEFINED, cvssV3_1.getConfidentialityRequirement());
 
         cvssV3_1.confidentialityRequirement(CvssV3_1.ConfidentialityRequirement.LOW);
@@ -576,7 +576,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:X/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.IntegrityRequirement.NOT_DEFINED, cvssV3_1.getIntegrityRequirement());
 
         cvssV3_1.integrityRequirement(CvssV3_1.IntegrityRequirement.LOW);
@@ -623,7 +623,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:X/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.AvailabilityRequirement.NOT_DEFINED, cvssV3_1.getAvailabilityRequirement());
 
         cvssV3_1.availabilityRequirement(CvssV3_1.AvailabilityRequirement.LOW);
@@ -670,7 +670,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:X/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ModifiedAttackVector.NOT_DEFINED, cvssV3_1.getModifiedAttackVector());
 
         cvssV3_1.modifiedAttackVector(CvssV3_1.ModifiedAttackVector.NETWORK);
@@ -728,7 +728,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:X/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ModifiedAttackComplexity.NOT_DEFINED, cvssV3_1.getModifiedAttackComplexity());
 
         cvssV3_1.modifiedAttackComplexity(CvssV3_1.ModifiedAttackComplexity.LOW);
@@ -764,7 +764,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:X/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MUI:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ModifiedPrivilegesRequired.NOT_DEFINED, cvssV3_1.getModifiedPrivilegesRequired());
 
         cvssV3_1.modifiedPrivilegesRequired(CvssV3_1.ModifiedPrivilegesRequired.NONE);
@@ -811,7 +811,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:X/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MS:U/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ModifiedUserInteraction.NOT_DEFINED, cvssV3_1.getModifiedUserInteraction());
 
         cvssV3_1.modifiedUserInteraction(CvssV3_1.ModifiedUserInteraction.NONE);
@@ -847,7 +847,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:X/MC:N/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MC:N/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ModifiedScope.NOT_DEFINED, cvssV3_1.getModifiedScope());
 
         cvssV3_1.modifiedScope(CvssV3_1.ModifiedScope.UNCHANGED);
@@ -883,7 +883,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:X/MI:N/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MI:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ModifiedCIA.NOT_DEFINED, cvssV3_1.getModifiedConfidentialityImpact());
 
         cvssV3_1.modifiedConfidentialityImpact(CvssV3_1.ModifiedCIA.NONE);
@@ -930,7 +930,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:X/MA:N", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MA:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ModifiedCIA.NOT_DEFINED, cvssV3_1.getModifiedIntegrityImpact());
 
         cvssV3_1.modifiedIntegrityImpact(CvssV3_1.ModifiedCIA.NONE);
@@ -977,7 +977,7 @@ public class CvssV3_1Test {
         assertEquals(0, score.getTemporalScore(), 0);
         assertEquals(0, score.getEnvironmentalScore(), 0);
         assertEquals(0, score.getModifiedImpactSubScore(), 0);
-        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N/MA:X", cvssV3_1.getVector());
+        assertEquals(null, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N/E:U/RL:O/RC:U/CR:L/IR:L/AR:L/MAV:N/MAC:L/MPR:N/MUI:N/MS:U/MC:N/MI:N", cvssV3_1.getVector());
         assertEquals(CvssV3_1.ModifiedCIA.NOT_DEFINED, cvssV3_1.getModifiedAvailabilityImpact());
 
         cvssV3_1.modifiedAvailabilityImpact(CvssV3_1.ModifiedCIA.NONE);
@@ -1070,7 +1070,7 @@ public class CvssV3_1Test {
         Assert.assertEquals(CvssV3.Exploitability.NOT_DEFINED, v3.getExploitability());
         Assert.assertEquals(CvssV3.RemediationLevel.NOT_DEFINED, v3.getRemediationLevel());
         Assert.assertEquals(CvssV3.ReportConfidence.CONFIRMED, v3.getReportConfidence());
-        assertEquals(cvss3Vector, cvssV3.getVector());
+        assertEquals("CVSS:3.0/AV:A/AC:H/PR:L/UI:R/S:C/C:L/I:H/A:L/RC:C", cvssV3.getVector());
 
         // With environmental vector elements
         cvss3Vector = "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:U/RL:T/RC:R/CR:L/IR:M/AR:L/MAV:P/MAC:H/MPR:N/MUI:R/MS:U/MC:L/MI:L/MA:L";
@@ -1101,4 +1101,15 @@ public class CvssV3_1Test {
         Assert.assertEquals(CvssV3_1.ModifiedCIA.LOW, v3_1.getModifiedAvailabilityImpact());
         assertEquals(cvss3Vector, cvssV3.getVector());
     }
+
+    @Test
+    public void testTemporalScoreWithPartiallyProvidedMetrics() {
+        final Cvss cvss = Cvss.fromVector("CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L/E:F");
+        final Score score = cvss.calculateScore();
+
+        Assert.assertEquals(7.6, score.getBaseScore(), 0);
+        Assert.assertEquals(7.4, score.getTemporalScore(), 0);
+        Assert.assertEquals(7.4, score.getEnvironmentalScore(), 0);
+    }
+
 }


### PR DESCRIPTION
Replaces the regex-based parsing with pattern matching. The new implementation is able to detect:

* Missing mandatory metrics
* Extraneous, unknown metrics
* Invalid metric values
* Invalid metric formats

In all above cases, a `MalformedVectorException` is thrown, containing details about the issue at hand. Previously, trying to parse an invalid vector merely resulted in a `null` return value.

Parsing is now able to properly detect whether the provided vector is CVSSv3.0 or CVSSv3.1, which addresses #56.

> [!NOTE]
> This implementation does **not** enforce metric order for CVSSv2.

Closes https://github.com/stevespringett/cvss-calculator/issues/49
Fixes https://github.com/stevespringett/cvss-calculator/issues/56

---

Additionally, defaults optional metrics to "Not Defined".

Score calculation is not designed to deal with `null` values. If a metric is not provided, it is assumed to be "Not Defined" (`ND` for CVSSv2, `X` for CVSSv3). This ensures that score calculation continues to work, when only a subset of optional metrics is provided.

Metrics with "Not Defined" values are omitted when constructing a vector string. This is in line with how visual CVSS calculators operate.

Initialization of metrics with `null` is prevented via `Objects#requireNonNull` checks on setters.

Fixes https://github.com/stevespringett/cvss-calculator/issues/65